### PR TITLE
Fixing bug with not being able to equip non-piercing jutsu

### DIFF
--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -277,6 +277,9 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = ({
                 >
                   Last IP: {profile.lastIp}
                 </Link>
+                <div>
+                  {profile.deletionAt ? `To be deleted on: ${profile.deletionAt}` : ""}
+                </div>
               </div>
             )}
           </div>

--- a/app/src/server/api/routers/jutsu.ts
+++ b/app/src/server/api/routers/jutsu.ts
@@ -415,6 +415,9 @@ export const jutsuRouter = createTRPCRouter({
       const pierceEquipped = equippedJutsus.filter((j) =>
         j.jutsu.effects.some((e) => e.type === "pierce"),
       ).length;
+      const curJutsuIsPierce = userjutsu?.jutsu.effects.some(
+        (e) => e.type === "pierce",
+      );
       const newEquippedState = isEquipped ? 0 : 1;
       const loadout = loadouts.find((l) => l.id === user.jutsuLoadout);
       const isLoaded = userjutsu && loadout?.jutsuIds.includes(userjutsu.jutsuId);
@@ -423,7 +426,7 @@ export const jutsuRouter = createTRPCRouter({
       if (!isEquipped && curEquip >= maxEquip) {
         return errorResponse("You cannot equip more jutsu");
       }
-      if (!isEquipped && pierceEquipped >= 2) {
+      if (!isEquipped && curJutsuIsPierce && pierceEquipped >= 2) {
         return errorResponse("You cannot equip more than 2 piercing jutsu");
       }
       // Calculate loadout

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -797,6 +797,7 @@ export const profileRouter = createTRPCRouter({
             userId: true,
             username: true,
             pveFights: true,
+            deletionAt: true,
           },
           with: {
             village: true,


### PR DESCRIPTION
# Pull Request

Fixing bug with not being able to equip non-piercing jutsu when 2 piercing are equipped, and showing deleted at flag on public profile for mods/admins

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
