### PR TITLE
Fix Ramen discount not working

### DIFF
--- a/app/src/app/ramenshop/page.tsx
+++ b/app/src/app/ramenshop/page.tsx
@@ -95,8 +95,14 @@ const MenuEntry: React.FC<MenuEntryProps> = (props) => {
   // Destructure
   const { title, entry, image, userData, onPurchase } = props;
 
-  // Get structures
-  const discount = structureBoost("ramenDiscountPerLvl", userData.village?.structures);
+  // Get current village
+  const { data: sectorVillage } = api.travel.getVillageInSector.useQuery(
+    { sector: userData?.sector ?? -1, isOutlaw: userData?.isOutlaw ?? false },
+    { enabled: !!userData },
+  );
+  
+  // Get structure discount
+  const discount = structureBoost("ramenDiscountPerLvl", sectorVillage?.structures);
 
   // Convenience
   const factor = (100 - discount) / 100;

--- a/app/src/server/api/routers/village.ts
+++ b/app/src/server/api/routers/village.ts
@@ -71,12 +71,12 @@ export const villageRouter = createTRPCRouter({
     .input(z.object({ ramen: z.enum(ramenOptions), villageId: z.string().nullish() }))
     .output(baseServerResponse)
     .mutation(async ({ ctx, input }) => {
-      // Query
-      const [user, structures] = await Promise.all([
-        fetchUser(ctx.drizzle, ctx.userId),
-        fetchStructures(ctx.drizzle, input.villageId),
-      ]);
-      // Derived
+      // Get structures of current (visiting) village or Sydicate if outlaw
+      const user = await fetchUser(ctx.drizzle, ctx.userId);
+      const village = await fetchSectorVillage(ctx.drizzle, user.sector, user.isOutlaw);
+      const structures = await fetchStructures(ctx.drizzle, village.id);
+
+      // Calculate cost
       const discount = structureBoost("ramenDiscountPerLvl", structures);
       const factor = (100 - discount) / 100;
       const healPercentage = getRamenHealPercentage(input.ramen);


### PR DESCRIPTION
# Pull Request

Right now the ramen discount doesn't get applied. It only shows the discounted price in the UI, but the full, undiscounted price is deducted when you buy the ramen. 
Also right now code always applies the ramen discount of the players home village, it makes more sense if a player visits an allied village that the discount of that village is used instead.

![10081bae54985308ce5167fe87b134d2](https://github.com/user-attachments/assets/4317eb11-eb14-4142-89b5-4f8ab39ffc39)
^Should cost 44.5 ryo (50% discount), but 89 is charged


## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
