### PR TITLE
Fix Ramen Shop discount, Show only players inside village at hospital

### DIFF
--- a/app/src/app/hospital/page.tsx
+++ b/app/src/app/hospital/page.tsx
@@ -11,6 +11,7 @@ import Image from "next/image";
 import { hasRequiredRank } from "@/libs/train";
 import { Button } from "@/components/ui/button";
 import { structureBoost } from "@/utils/village";
+import { calcIsInVillage } from "@/libs/travel/controls";
 import { useRequireInVillage } from "@/utils/UserContext";
 import { api } from "@/app/_trpc/client";
 import { showMutationToast } from "@/libs/toast";
@@ -203,7 +204,7 @@ const HealOthersComponent: React.FC<HealOthersComponentProps> = (props) => {
     refetchInterval: 5000,
     enabled: !!userData,
   });
-  const allHospitalized = hospitalized?.map((user) => {
+  const allHospitalized = hospitalized?.filter((user) => calcIsInVillage({x: user.longitude, y: user.latitude}) === true).map((user) => {
     const missingHealth = user.maxHealth - user.curHealth;
     return {
       ...user,

--- a/app/src/app/ramenshop/page.tsx
+++ b/app/src/app/ramenshop/page.tsx
@@ -98,8 +98,14 @@ const MenuEntry: React.FC<MenuEntryProps> = (props) => {
   // Destructure
   const { title, entry, image, userData, onPurchase } = props;
 
-  // Get structures
-  const discount = structureBoost("ramenDiscountPerLvl", userData.village?.structures);
+  // Get current village
+  const { data: sectorVillage } = api.travel.getVillageInSector.useQuery(
+    { sector: userData?.sector ?? -1, isOutlaw: userData?.isOutlaw ?? false },
+    { enabled: !!userData },
+  );
+
+  // Get structure discount
+  const discount = structureBoost("ramenDiscountPerLvl", sectorVillage?.structures);
 
   // Convenience
   const factor = (100 - discount) / 100;

--- a/app/src/libs/travel/controls.ts
+++ b/app/src/libs/travel/controls.ts
@@ -48,7 +48,7 @@ export const calcIsInVillage = (position: SectorPoint) => {
     if ([1, 2, 3, 17, 18].includes(position.x)) return false;
   }
   if (position.y === 1) {
-    if ([1, 2, 3, 16, 17, 18].includes(position.x)) return false;
+    if ([1, 2, 3, 4, 16, 17, 18].includes(position.x)) return false;
   }
   if (position.y === 2) {
     if ([1, 2, 18].includes(position.x)) return false;

--- a/app/src/server/api/routers/hospital.ts
+++ b/app/src/server/api/routers/hospital.ts
@@ -48,6 +48,8 @@ export const hospitalRouter = createTRPCRouter({
         level: true,
         status: true,
         sector: true,
+        longitude: true,
+        latitude: true,
         rank: true,
         isOutlaw: true,
       },

--- a/app/src/server/api/routers/village.ts
+++ b/app/src/server/api/routers/village.ts
@@ -78,12 +78,12 @@ export const villageRouter = createTRPCRouter({
       }),
     )
     .mutation(async ({ ctx, input }) => {
-      // Query
-      const [user, structures] = await Promise.all([
-        fetchUser(ctx.drizzle, ctx.userId),
-        fetchStructures(ctx.drizzle, input.villageId),
-      ]);
-      // Derived
+      // Get structures of current (visiting) village or Sydicate if outlaw
+      const user = await fetchUser(ctx.drizzle, ctx.userId);
+      const village = await fetchSectorVillage(ctx.drizzle, user.sector, user.isOutlaw);
+      const structures = await fetchStructures(ctx.drizzle, village?.id);
+
+      // Calculate cost
       const discount = structureBoost("ramenDiscountPerLvl", structures);
       const factor = (100 - discount) / 100;
       const healPercentage = getRamenHealPercentage(input.ramen);


### PR DESCRIPTION
# Pull Request
Fix: Right now the ramen discount doesn't get applied. It only shows the discounted price in the UI, but the full, undiscounted price is deducted when you buy the ramen.

Add: Also code always applied the ramen discount of the players home village, it makes more sense if a player visits an allied village that the discount of that village is used instead

Fix: Right now all players in the sector are shown at the hospital for meds to heal them, but only players inside the village can be healed.

Fix: calcIsInVillage missing one location (4, 1)

![385248794-4317eb11-eb14-4142-89b5-4f8ab39ffc39](https://github.com/user-attachments/assets/b64c4dbc-bd98-46cb-ad15-53c3cf4e90a8)
^Should cost 44.5 ryo (50% discount), but 89 is charged

![a491e2ca19760d7e1fb34dba6bf8cc3d](https://github.com/user-attachments/assets/7ddb32bf-22bf-4aa7-8287-61c27a9bb0ab)
^Can't heal user outside the village, but user is still listed...

![image](https://github.com/user-attachments/assets/04d813e9-9829-497e-a6ef-87dcee3f0d72)
^4,1 still inside village


## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
