### PR TITLE
Fix drizzle config and /.env.example folder for deployment

### DIFF
--- a/app/.env.example
+++ b/app/.env.example
@@ -28,3 +28,6 @@ REPLICATE_API_TOKEN=placeholder
 
 # Uploadthing (optional)
 UPLOADTHING_TOKEN=placeholder
+
+#OpenAI API (Required)
+OPENAI_API_KEY=placeholder

--- a/app/drizzle.config.ts
+++ b/app/drizzle.config.ts
@@ -5,8 +5,6 @@ export default defineConfig({
   out: "./drizzle/migrations",
   schema: "./drizzle/schema.ts",
   dialect: "mysql",
-  ...(process.env.DATABASE_URL
-    ? { dbCredentials: { url: process.env.DATABASE_URL } }
-    : {}),
+  ...(process.env.MYSQL_URL ? { dbCredentials: { url: process.env.MYSQL_URL } } : {}),
   breakpoints: false,
 });


### PR DESCRIPTION
# Pull Request

First time doing a pull request. These two errors prevent people from being able to create their own environment.

Add Open AI API to /.env.example. Local TNR website will not load without this. 
Update drizzle.config.ts to use MYSQL_URL instead of DATABASE_URL. make dbpush command will fail. 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
