### PR TITLE
Fix issue #238: Friendly Fire are bugged in Spars

### DIFF
--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -35,8 +35,15 @@ export const checkFriendlyFire = (
   const creator = usersState.find((u) => u.userId === effect.creatorId);
   if (!creator) return false;
 
+  // Get battle type from the battle state
+  const battle = usersState[0]?.battle;
+  const battleType = battle?.battleType;
+
+  // In spars and kage battles, village alliance is ignored
+  const ignoreVillageAlliance = battleType === "SPARRING" || battleType === "KAGE_CHALLENGE";
+
   // In clan battles and other battles, players from same village are allies
-  const isFriendly = creator.villageId === target.villageId;
+  const isFriendly = !ignoreVillageAlliance && creator.villageId === target.villageId;
 
   // Check if effect should be applied based on friendly fire settings
   if (!effect.friendlyFire || effect.friendlyFire === "ALL") {

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -47,13 +47,20 @@ export const checkFriendlyFire = (
     return true; // Allow all
   }
 
-  // In spars and kage battles, treat everyone as enemies
+  // Get village alliance status
+  const isFriendly = creator.villageId === target.villageId;
+
+  // In spars and kage battles, treat everyone as enemies regardless of village
   if (ignoreVillageAlliance) {
-    return effect.friendlyFire === "ENEMIES";
+    if (effect.friendlyFire === "FRIENDLY") {
+      return false; // No friendly effects in spars/kage battles
+    }
+    if (effect.friendlyFire === "ENEMIES") {
+      return true; // Enemy effects hit everyone in spars/kage battles
+    }
   }
 
   // In other battles, check village alliance
-  const isFriendly = creator.villageId === target.villageId;
   if (effect.friendlyFire === "FRIENDLY") {
     return isFriendly; // Only apply to friends (same village)
   }

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -42,13 +42,18 @@ export const checkFriendlyFire = (
   // In spars and kage battles, village alliance is ignored
   const ignoreVillageAlliance = battleType === "SPARRING" || battleType === "KAGE_CHALLENGE";
 
-  // In clan battles and other battles, players from same village are allies
-  const isFriendly = !ignoreVillageAlliance && creator.villageId === target.villageId;
-
   // Check if effect should be applied based on friendly fire settings
   if (!effect.friendlyFire || effect.friendlyFire === "ALL") {
     return true; // Allow all
   }
+
+  // In spars and kage battles, treat everyone as enemies
+  if (ignoreVillageAlliance) {
+    return effect.friendlyFire === "ENEMIES";
+  }
+
+  // In other battles, check village alliance
+  const isFriendly = creator.villageId === target.villageId;
   if (effect.friendlyFire === "FRIENDLY") {
     return isFriendly; // Only apply to friends (same village)
   }

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -57,6 +57,7 @@ export type BattleUserState = UserWithRelations & {
   usedActions: { id: string; type: "jutsu" | "item" | "basic" | "bloodline" }[];
   hex?: TerrainHex;
   clan?: Clan | null;
+  battle?: { battleType: BattleType };
 };
 
 // Create type for battle, which contains information on user current state

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -860,6 +860,9 @@ export const processUsersForBattle = (info: {
     // Set controllerID and mark this user as the original
     user.controllerId = user.userId;
 
+    // Set battle type in user state
+    user.battle = { battleType };
+
     // Set direction
     user.direction = i % 2 === 0 ? "right" : "left";
 

--- a/app/tests/libs/combat/friendly_fire.test.ts
+++ b/app/tests/libs/combat/friendly_fire.test.ts
@@ -108,4 +108,42 @@ describe("checkFriendlyFire", () => {
       expect(checkFriendlyFire(effect, target, multiVillageUsers)).toBe(false);
     });
   });
+
+  describe("Sparring Battle", () => {
+    const sparUsers = [
+      { ...baseUser, battle: { battleType: "SPARRING" } },
+      { ...baseUser, userId: "user2", villageId: "village1", controllerId: "controller2", battle: { battleType: "SPARRING" } },
+    ];
+
+    it("should allow ENEMIES effects on same village in spars", () => {
+      const effect = { ...baseEffect, friendlyFire: "ENEMIES" };
+      const target = sparUsers[1]; // Same village, different controller
+      expect(checkFriendlyFire(effect, target, sparUsers)).toBe(true);
+    });
+
+    it("should block FRIENDLY effects on same village in spars", () => {
+      const effect = { ...baseEffect, friendlyFire: "FRIENDLY" };
+      const target = sparUsers[1]; // Same village, different controller
+      expect(checkFriendlyFire(effect, target, sparUsers)).toBe(false);
+    });
+  });
+
+  describe("Kage Challenge Battle", () => {
+    const kageUsers = [
+      { ...baseUser, battle: { battleType: "KAGE_CHALLENGE" } },
+      { ...baseUser, userId: "user2", villageId: "village1", controllerId: "controller2", battle: { battleType: "KAGE_CHALLENGE" } },
+    ];
+
+    it("should allow ENEMIES effects on same village in kage challenges", () => {
+      const effect = { ...baseEffect, friendlyFire: "ENEMIES" };
+      const target = kageUsers[1]; // Same village, different controller
+      expect(checkFriendlyFire(effect, target, kageUsers)).toBe(true);
+    });
+
+    it("should block FRIENDLY effects on same village in kage challenges", () => {
+      const effect = { ...baseEffect, friendlyFire: "FRIENDLY" };
+      const target = kageUsers[1]; // Same village, different controller
+      expect(checkFriendlyFire(effect, target, kageUsers)).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
This pull request fixes #238.

The issue has been successfully resolved. The AI made targeted changes to the `checkFriendlyFire` function to specifically handle SPARRING and KAGE_CHALLENGE battle types differently from regular battles. 

For a human reviewer:
This PR fixes the friendly fire issue in same-village sparring matches by:
1. Adding a new condition to ignore village alliance checks during SPARRING and KAGE_CHALLENGE battles
2. Maintaining existing village alliance checks for all other battle types
3. Including comprehensive test coverage for both sparring and kage challenge scenarios

The solution directly addresses the original issue by allowing jutsu attacks marked as "enemy" to properly affect players from the same village during spars and kage battles, while preserving the existing alliance behavior in other battle types. The passing tests confirm the functionality works as intended.

Key changes:
- Modified `checkFriendlyFire` in process.ts to handle battle-type specific logic
- Added test suites to verify the behavior in both sparring and kage challenge contexts
- Maintained backward compatibility for other battle types

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌