### PR TITLE
Fix issue #245: Clear Tag does not affect ground effects 

### DIFF
--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -539,6 +539,7 @@ const removeEffects = (
 
   // Note: add !effect.castThisRound && to remove effects only after the round
   if (effect.power === 100) {
+    // Remove user effects
     usersEffects
       .filter((e) => e.targetId === effect.targetId)
       .filter((e) => e.fromType !== "bloodline")
@@ -547,6 +548,16 @@ const removeEffects = (
       .map((e) => {
         e.rounds = 0;
       });
+
+    // Remove ground effects at the same location as the target
+    usersEffects
+      .filter((e) => !("targetId" in e)) // Ground effects don't have targetId
+      .filter((e) => e.longitude === target.longitude && e.latitude === target.latitude)
+      .filter(type === "positive" ? isPositiveUserEffect : isNegativeUserEffect)
+      .map((e) => {
+        e.rounds = 0;
+      });
+
     text = `${target.username} was cleared of all ${type} status effects. `;
     effect.rounds = 0;
   }

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -549,9 +549,12 @@ const removeEffects = (
         e.rounds = 0;
       });
 
+    // Type guard to identify ground effects
+    const isGroundEffect = (e: UserEffect | GroundEffect): e is GroundEffect => !("targetId" in e);
+
     // Remove ground effects at the same location as the target
     usersEffects
-      .filter((e) => !("targetId" in e)) // Ground effects don't have targetId
+      .filter(isGroundEffect)
       .filter((e) => e.longitude === target.longitude && e.latitude === target.latitude)
       .filter(type === "positive" ? isPositiveUserEffect : isNegativeUserEffect)
       .map((e) => {


### PR DESCRIPTION
This pull request fixes #245.

The issue appears to be successfully resolved based on the AI agent's explanation. The fix directly addresses the core problem by modifying the `removeEffects` function to handle ground effects, which was the original issue. Specifically:

1. The solution identifies that ground effects were being ignored because they lack a `targetId`
2. The fix adds logic to handle effects without a `targetId` (ground effects)
3. It maintains existing functionality for user-targeted effects while adding the new ground effect handling
4. The solution uses location-based checking (longitude/latitude) to ensure ground effects are removed at the user's location
5. The tests have passed, indicating the implementation works as expected

For a human reviewer, I would summarize this PR as:
"This PR fixes the clear/cleanse tag functionality for ground effects by modifying the removeEffects function to handle both user-targeted and ground effects. Ground effects are now properly identified by their lack of targetId and removed based on the user's location coordinates. The existing functionality for user effects is preserved while adding this new capability. All tests are passing."

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌