### PR TITLE
Update jutsu.ts

### DIFF
--- a/app/src/server/api/routers/jutsu.ts
+++ b/app/src/server/api/routers/jutsu.ts
@@ -481,7 +481,7 @@ export const jutsuRouter = createTRPCRouter({
       );
       // Guard
       if (
-        residualJutsus.length > JUTSU_MAX_RESIDUAL_EQUIPPED &&
+        residualJutsus.length >= JUTSU_MAX_RESIDUAL_EQUIPPED &&
         newEquippedState === 1
       ) {
         return errorResponse(


### PR DESCRIPTION
Logic allowed 4 residual jutsu to be tagged and gave error on 5th. Now gives error when attempting to tag the 4th.

# Pull Request

**Please fill: what was implemented, why, possibly include screenshots, are any of the changes breaking, etc.**

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
