### PR TITLE
Fix issue #302: Users cannot be cleansed of decreaseHeal tag or healP…

### DIFF
--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -744,7 +744,6 @@ export const isPositiveUserEffect = (tag: ZodAllTags) => {
       "decreasepoolcost",
       "heal",
       "lifesteal",
-      "healprevent",
       "increasedamagegiven",
       "increaseheal",
       "increasestat",
@@ -776,7 +775,7 @@ export const isNegativeUserEffect = (tag: ZodAllTags) => {
       // "buffprevent",
       "decreasedamagegiven",
       "increasedamagetaken",
-      "decreasehealgiven",
+      "decreaseheal",
       "increasepoolcost",
       "decreasestat",
       "clear",
@@ -791,6 +790,7 @@ export const isNegativeUserEffect = (tag: ZodAllTags) => {
       "seal",
       "summonprevent",
       "weakness",
+      "healprevent",
     ].includes(tag.type)
   ) {
     return true;


### PR DESCRIPTION
# Pull Request

The constant DecreaseHealGivenTag was looking for a literal of "decreaseheal" which was correct.  The issue, is in the list for isNegativeUserEffect, instead of "decreaseheal" it was "decreasehealgiven".  I updated this to "decreaseheal" in the list so that it can be properly found when someone is attempting to cleanse "decreaseheal" effects on them.

I also moved "healprevent" from being in the isPositiveUserEffect list to the isNegativeUserEffect list.  With the healprevent being in the wrong list, if a user effected their opponent with it, it was treated as a positive effect.  So if they were cleared by the enemy, it would fall off instead of staying on.  This was also preventing those effected by it from cleansing themselves of the debuff.

Fix #302 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
