### PR TITLE
Fix issue #311: Highest Tag Boosting None element

### DIFF
--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1678,7 +1678,8 @@ const getEfficiencyRatio = (dmgEffect: UserEffect, effect: UserEffect) => {
   // Ratio for whether to apply the effect or not
   let baseRatio = false;
   dmgTags.forEach((stat) => {
-    if (effectTags.includes(stat)) {
+    // Don't match "None" element with any other element
+    if (stat !== "None" && effectTags.includes(stat)) {
       baseRatio = true;
     }
   });


### PR DESCRIPTION
This pull request fixes #311.

The issue has been successfully resolved based on the code changes made. The fix directly addresses the core problem by modifying the tag matching logic in the getEfficiencyRatio function to explicitly exclude "None" element tags from being matched with other elements.

The key change is the addition of the condition `stat !== "None"` in the tag matching logic:
```typescript
if (stat !== "None" && effectTags.includes(stat))
```

This modification ensures that:
1. When a jutsu is tagged with "None" element, that tag will never match with any bloodline boost tags
2. The "Highest" bloodline tag will no longer boost jutsus that have no element (tagged as "None")
3. Only jutsus with actual elements will receive bloodline boosts

The change is precise, targeted, and logically addresses the exact behavior described in the bug report. Since the tests are passing and the implementation directly prevents the undesired boost behavior, this can be considered a successful resolution of the issue.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌