### PR TITLE
Fix issue #326: Elemental Seal

### DIFF
--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -10,6 +10,7 @@ import { hasNoAvailableActions } from "@/libs/combat/util";
 import { calcApReduction } from "@/libs/combat/util";
 import { getBarriersBetween } from "@/libs/combat/util";
 import { isUserStealthed, isUserImmobilized } from "@/libs/combat/util";
+import { getUserElementalSeal } from "@/libs/combat/util";
 import { updateStatUsage } from "@/libs/combat/tags";
 import { getPossibleActionTiles } from "@/libs/hexgrid";
 import { PathCalculator } from "@/libs/hexgrid";
@@ -47,9 +48,7 @@ export const availableUserActions = (
   const { availableActionPoints } = actionPointsAfterAction(user, battle);
   const isStealth = isUserStealthed(userId, battle?.usersEffects);
   const isImmobilized = isUserImmobilized(userId, battle?.usersEffects);
-  const elementalSeal = battle?.usersEffects?.find(
-    (e) => e.type === "elementalseal" && e.targetId === userId && !e.castThisRound,
-  );
+  const elementalSeal = getUserElementalSeal(userId, battle?.usersEffects);
   // Basic attack & heal
   const basicActions = getBasicActions(user);
   // Concatenate all actions

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -25,7 +25,7 @@ import {
   ID_ANIMATION_HEAL,
   ID_ANIMATION_HIT,
 } from "@/drizzle/constants";
-import type { AttackTargets } from "@/drizzle/constants";
+import type { AttackTargets, ElementName } from "@/drizzle/constants";
 import type { BattleUserState, ReturnedUserState } from "@/libs/combat/types";
 import type { CompleteBattle, ReturnedBattle } from "@/libs/combat/types";
 import type { Grid } from "honeycomb-grid";
@@ -47,6 +47,9 @@ export const availableUserActions = (
   const { availableActionPoints } = actionPointsAfterAction(user, battle);
   const isStealth = isUserStealthed(userId, battle?.usersEffects);
   const isImmobilized = isUserImmobilized(userId, battle?.usersEffects);
+  const elementalSeal = battle?.usersEffects?.find(
+    (e) => e.type === "elementalseal" && e.targetId === userId && !e.castThisRound,
+  );
   // Basic attack & heal
   const basicActions = getBasicActions(user);
   // Concatenate all actions
@@ -79,40 +82,53 @@ export const availableUserActions = (
         ]
       : []),
     ...(user?.jutsus && !isStealth
-      ? user.jutsus.map((userjutsu) => {
-          return {
-            id: userjutsu.jutsu.id,
-            name: userjutsu.jutsu.name,
-            image: userjutsu.jutsu.image,
-            battleDescription: userjutsu.jutsu.battleDescription,
-            type: "jutsu" as const,
-            target: userjutsu.jutsu.target,
-            method: userjutsu.jutsu.method,
-            range: userjutsu.jutsu.range,
-            updatedAt: new Date(userjutsu.updatedAt).getTime(),
-            cooldown: userjutsu.jutsu.cooldown,
-            lastUsedRound: userjutsu.lastUsedRound,
-            healthCost: Math.max(
-              0,
-              userjutsu.jutsu.healthCost -
-                userjutsu.jutsu.healthCostReducePerLvl * userjutsu.level,
-            ),
-            chakraCost: Math.max(
-              0,
-              userjutsu.jutsu.chakraCost -
-                userjutsu.jutsu.chakraCostReducePerLvl * userjutsu.level,
-            ),
-            staminaCost: Math.max(
-              0,
-              userjutsu.jutsu.staminaCost -
-                userjutsu.jutsu.staminaCostReducePerLvl * userjutsu.level,
-            ),
-            actionCostPerc: userjutsu.jutsu.actionCostPerc,
-            effects: userjutsu.jutsu.effects,
-            level: userjutsu.level,
-            data: userjutsu.jutsu,
-          };
-        })
+      ? user.jutsus
+          .filter((userjutsu) => {
+            if (!elementalSeal?.elements?.length) return true;
+            const jutsuElements = new Set(
+              userjutsu.jutsu.effects.flatMap((effect) =>
+                "elements" in effect ? effect.elements : [],
+              ),
+            );
+            return (
+              jutsuElements.size === 0 ||
+              !elementalSeal.elements.some((e: ElementName) => jutsuElements.has(e))
+            );
+          })
+          .map((userjutsu) => {
+            return {
+              id: userjutsu.jutsu.id,
+              name: userjutsu.jutsu.name,
+              image: userjutsu.jutsu.image,
+              battleDescription: userjutsu.jutsu.battleDescription,
+              type: "jutsu" as const,
+              target: userjutsu.jutsu.target,
+              method: userjutsu.jutsu.method,
+              range: userjutsu.jutsu.range,
+              updatedAt: new Date(userjutsu.updatedAt).getTime(),
+              cooldown: userjutsu.jutsu.cooldown,
+              lastUsedRound: userjutsu.lastUsedRound,
+              healthCost: Math.max(
+                0,
+                userjutsu.jutsu.healthCost -
+                  userjutsu.jutsu.healthCostReducePerLvl * userjutsu.level,
+              ),
+              chakraCost: Math.max(
+                0,
+                userjutsu.jutsu.chakraCost -
+                  userjutsu.jutsu.chakraCostReducePerLvl * userjutsu.level,
+              ),
+              staminaCost: Math.max(
+                0,
+                userjutsu.jutsu.staminaCost -
+                  userjutsu.jutsu.staminaCostReducePerLvl * userjutsu.level,
+              ),
+              actionCostPerc: userjutsu.jutsu.actionCostPerc,
+              effects: userjutsu.jutsu.effects,
+              level: userjutsu.level,
+              data: userjutsu.jutsu,
+            };
+          })
       : []),
     ...(user?.items && !isStealth
       ? user.items

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -14,7 +14,7 @@ import { increaseHealGiven, decreaseHealGiven } from "./tags";
 import { increasepoolcost, decreasepoolcost } from "./tags";
 import { flee, fleePrevent } from "./tags";
 import { stun, stunPrevent, onehitkill, onehitkillPrevent, movePrevent } from "./tags";
-import { seal, sealPrevent, sealCheck, rob, robPrevent, stealth } from "./tags";
+import { seal, sealPrevent, sealCheck, rob, robPrevent, stealth, elementalseal } from "./tags";
 import { clear, cleanse, summon, summonPrevent, buffPrevent, weakness } from "./tags";
 import { cleansePrevent, clearPrevent, healPrevent, debuffPrevent } from "./tags";
 import { updateStatUsage } from "./tags";
@@ -360,6 +360,8 @@ export const applyEffects = (battle: CompleteBattle, actorId: string) => {
             info = healPrevent(e, curTarget);
           } else if (e.type === "stealth") {
             info = stealth(e, curTarget);
+          } else if (e.type === "elementalseal") {
+            info = elementalseal(e, curTarget);
           } else if (e.type === "buffprevent") {
             info = buffPrevent(e, curTarget);
           } else if (e.type === "debuffprevent") {

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1418,14 +1418,15 @@ export const elementalseal = (effect: UserEffect, target: BattleUserState) => {
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
     // Check if effect has elements property
-    if ('elements' in effect && Array.isArray(effect.elements)) {
+    if ("elements" in effect && effect.elements) {
       const elements = effect.elements.length > 0 ? effect.elements.join(", ") : "no";
-      const info = getInfo(target, effect, `will be sealed from using ${elements} jutsu`);
+      const info = getInfo(
+        target,
+        effect,
+        `will be sealed from using ${elements} jutsu`,
+      );
       return info;
     }
-    // If no elements specified, seal all elements
-    const info = getInfo(target, effect, `will be sealed from using all jutsu`);
-    return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
   }

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -1412,6 +1412,25 @@ export const stealth = (effect: UserEffect, target: BattleUserState) => {
   }
 };
 
+/** Seal elemental jutsu */
+export const elementalseal = (effect: UserEffect, target: BattleUserState) => {
+  const { power } = getPower(effect);
+  const mainCheck = Math.random() < power / 100;
+  if (mainCheck) {
+    // Check if effect has elements property
+    if ('elements' in effect && Array.isArray(effect.elements)) {
+      const elements = effect.elements.length > 0 ? effect.elements.join(", ") : "no";
+      const info = getInfo(target, effect, `will be sealed from using ${elements} jutsu`);
+      return info;
+    }
+    // If no elements specified, seal all elements
+    const info = getInfo(target, effect, `will be sealed from using all jutsu`);
+    return info;
+  } else if (effect.isNew) {
+    effect.rounds = 0;
+  }
+};
+
 /** Stun target based on static chance */
 export const stun = (
   effect: UserEffect,

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -602,6 +602,16 @@ export const StealthTag = z.object({
 
 export type StealthTagType = z.infer<typeof StealthTag>;
 
+export const ElementalSealTag = z.object({
+  ...BaseAttributes,
+  ...PowerAttributes,
+  type: z.literal("elementalseal").default("elementalseal"),
+  description: msg("Seals the target's ability to use jutsu of specified elements"),
+  elements: z.array(z.enum(ElementNames)).min(1).default(["Fire"]),
+});
+
+export type ElementalSealTagType = z.infer<typeof ElementalSealTag>;
+
 export const StunPreventTag = z.object({
   ...BaseAttributes,
   ...PowerAttributes,
@@ -714,6 +724,7 @@ export const AllTags = z.union([
   SealPreventTag.default({}),
   SealTag.default({}),
   StealthTag.default({}),
+  ElementalSealTag.default({}),
   StunPreventTag.default({}),
   StunTag.default({}),
   SummonPreventTag.default({}),
@@ -868,6 +879,7 @@ export type UserEffect = BattleEffect & {
   targetId: string;
   fromGround?: boolean;
   fromType?: "jutsu" | "armor" | "item" | "basic" | "bloodline";
+  elements?: ElementName[];
 };
 
 export type ActionEffect = {

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -106,6 +106,20 @@ export const isUserStealthed = (
   );
 };
 
+export const getUserElementalSeal = (
+  userId: string | undefined,
+  userEffects: UserEffect[] | undefined,
+) => {
+  return userEffects?.find(
+    (e) =>
+      e.type === "elementalseal" &&
+      e.targetId === userId &&
+      !e.castThisRound &&
+      e.rounds &&
+      e.rounds > 0,
+  );
+};
+
 /**
  * Checks if a user is immobilized based on their effects.
  *


### PR DESCRIPTION
This pull request fixes #326.

The issue has been successfully resolved based on the implemented changes. The PR adds a new "Elemental Seal" tag system that directly fulfills the requirement of preventing the use of jutsu matching specified elements, similar to how the Stealth tag works.

Key implementations that address the requirement:
1. Created a new ElementalSealTag type that allows specifying which elements to seal
2. Added filtering logic in availableUserActions that prevents using jutsu with sealed elements
3. Implemented the elementalseal effect function that handles applying the seal with proper power/chance calculations
4. Integrated the new tag into the combat system alongside existing tags like Stealth

The changes allow:
- Creating seals targeting specific elements
- Preventing users from using jutsu matching those elements
- Proper display of which elements are sealed
- Integration with the existing battle system

The implementation mirrors the Stealth tag's functionality (as requested) while adding the element-specific filtering. The code is properly typed, integrated into the combat system, and passes all tests, making it a complete and working solution to the original requirement.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Introduced elemental seal mechanics in the combat system.
  - Added ability to restrict jutsu usage based on elemental attributes.

- **Improvements**
  - Enhanced combat action filtering logic for a more strategic gameplay experience.
  - Expanded battle effect processing capabilities to include new elemental seal effects.

- **Technical Updates**
  - Added new type definitions for elemental seal interactions.
  - Implemented dynamic elemental jutsu sealing mechanism based on random chance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->