### PR TITLE
Fix issue #346: Users can be robbed in hospital and during pvp immunity

### DIFF
--- a/app/src/server/api/routers/travel.ts
+++ b/app/src/server/api/routers/travel.ts
@@ -77,6 +77,7 @@ export const travelRouter = createTRPCRouter({
       if (user.status !== "AWAKE") return errorResponse("You are not awake");
       if (user.isBanned) return errorResponse("You are banned");
       if (target.isBanned) return errorResponse("Target is banned");
+      if (target.status !== "AWAKE") return errorResponse("Target cannot currently be robbed");
       if (user.clanId === target.clanId)
         return errorResponse("Cannot rob faction members");
       if (target.rank === "STUDENT" || target.rank === "GENIN") {
@@ -86,6 +87,9 @@ export const travelRouter = createTRPCRouter({
         return errorResponse("Cannot rob players in this zone");
       }
       if (target.robImmunityUntil && target.robImmunityUntil > new Date()) {
+        return errorResponse("Target is immune from being robbed");
+      }
+      if (target.immunityUntil && target.immunityUntil > new Date()) {
         return errorResponse("Target is immune from being robbed");
       }
       if (


### PR DESCRIPTION
# Pull Request

Added logic to prevent users from being robbed under pvp immunity or while their status in not awake.  This prevents users from being robbed while asleep or hospitalized.  Users were able to be robbed while pvp immune an hospitalized.  Due to their status, combat was not trigger either when the rob attempt failed. 

Fix #346 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced player robbery validation
	- Added checks to prevent robbing players who are:
		- Not awake
		- Currently immune

<!-- end of auto-generated comment: release notes by coderabbit.ai -->