### PR TITLE
Fix issue #361: Make ElementalSeal cleansable

### DIFF
--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -819,6 +819,7 @@ export const isNegativeUserEffect = (tag: ZodAllTags) => {
       "summonprevent",
       "weakness",
       "healprevent",
+      "elementalseal",
     ].includes(tag.type)
   ) {
     return true;


### PR DESCRIPTION
# Pull Request

Added elemental seal as a negative use effect. Fix #361 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated gameplay logic to classify an additional negative status effect during combat. Now, when this specific effect occurs, it is consistently recognized as detrimental, leading to more balanced and refined interactions during battle engagements. Players should experience improved behavior when encountering such effects in gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->