### PR TITLE
:hammer: change bun tsx -> bun run to fix seed execution

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,7 +15,7 @@
     "preview": "next build && next start",
     "start": "next start",
     "test": "vitest",
-    "seed": "bun tsx drizzle/seed.ts",
+    "seed": "bun run drizzle/seed.ts",
     "dbpush": "drizzle-kit push",
     "makemigrations": "drizzle-kit generate",
     "emptymigration": "drizzle-kit generate --custom",


### PR DESCRIPTION
# Pull Request

`bun tsx` was actually doing nothing when i was trying to run it.

![image](https://github.com/user-attachments/assets/71123570-cd30-433c-bba7-f2d22cf90997)

Changing to `bun run` fixed that


## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the command used for seeding application data, enhancing execution consistency and environmental alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->