### PR TITLE
Fix Issue #370: Locking challenges does not deduct prestige.

### DIFF
--- a/app/vercel.json
+++ b/app/vercel.json
@@ -47,6 +47,10 @@
     {
       "path": "/api/daily-link-cleaner",
       "schedule": "0/10 0 * * *"
+    },
+    {
+      "path": "/api/hourly-kage-prestige",
+      "schedule": "0 * * * *"
     }
   ],
   "functions": {


### PR DESCRIPTION
# Pull Request

The api call for hourly-kage-prestige was not added to the cron schedule, therefore kages who were battle locked were not losing prestige every hour.  This change corrects it so that VP should be lost hourly.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a scheduled background task that runs every hour, enhancing the application's operational efficiency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->