### PR TITLE
Fix missing speed stat title in profile tooltip

### DIFF
--- a/app/src/layout/StrengthWeaknesses.tsx
+++ b/app/src/layout/StrengthWeaknesses.tsx
@@ -176,7 +176,9 @@ const StrengthWeaknesses: React.FC = () => {
                   <li>
                     <b>Intelligence:</b> mental strength
                   </li>
-                  <li>movement speed</li>
+                  <li>
+                    <b>Speed:</b> movement speed
+                  </li>
                   <li>
                     <b>Willpower:</b> mental resistance
                   </li>


### PR DESCRIPTION
# Pull Request

![Screenshot 2025-02-19 005211](https://github.com/user-attachments/assets/d93ab0a5-36bb-48a4-b0c5-7f68f08e327d)
Minor verbiage fix. This tooltip in the profile page for stats is missing the "Speed" stat.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Enhanced the visual clarity of the stats list by updating the "Speed" label to use bold formatting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->