### PR TITLE
Fix Issue #401: Clan/Faction bugs causing issues

### DIFF
--- a/app/src/validators/clan.ts
+++ b/app/src/validators/clan.ts
@@ -1,16 +1,47 @@
 import { z } from "zod";
 import type { Clan } from "@/drizzle/schema";
 
+const bannedNames = [
+  "Freedom State",
+  "Tsukimori",
+  "Glacier",
+  "Shine",
+  "Current",
+  "Shroud",
+];
+
 export const clanCreateSchema = z.object({
   villageId: z.string(),
-  name: z.string().trim().min(3).max(88),
+  name: z
+    .string()
+    .trim()
+    .min(3)
+    .max(88)
+    .refine(
+      (name) =>
+        !bannedNames.some(
+          (banned) => banned.toLowerCase() === name.toLowerCase()
+        ),
+      { message: "This clan name is not allowed." }
+    ),
 });
 
 export type ClanCreateSchema = z.infer<typeof clanCreateSchema>;
 
 export const clanRenameSchema = z.object({
   clanId: z.string(),
-  name: z.string().trim().min(3).max(88),
+  name: z
+    .string()
+    .trim()
+    .min(3)
+    .max(88)
+    .refine(
+      (name) =>
+        !bannedNames.some(
+          (banned) => banned.toLowerCase() === name.toLowerCase()
+        ),
+      { message: "This clan name is not allowed." }
+    ),
   image: z.string(),
 });
 


### PR DESCRIPTION
# Pull Request

Users are currently able to name a clan/faction after a village.  Creating a hideout after doing so causes an application error with the clan page.  

Users are also able to place an existing hideout on top of another one.  Both hideouts disappear when this happens.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced clan name validation now prevents the use of inappropriate names by giving clear feedback if a prohibited clan name is entered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->