### PR TITLE
Fix Issue #412: Users are still able to submit messages when silenced

### DIFF
--- a/app/src/layout/Conversation.tsx
+++ b/app/src/layout/Conversation.tsx
@@ -219,7 +219,16 @@ const Conversation: React.FC<ConversationProps> = (props) => {
   /**
    * Submit comment
    */
-  const handleSubmitComment = handleSubmit((data) => createComment(data));
+  const handleSubmitComment = handleSubmit((data) => {
+    if (userData?.isSilenced) {
+      showMutationToast({
+        success: false,
+        message: "You are silenced and cannot send a message.",
+      });
+      return;
+    }
+    createComment(data);
+  });
 
   /**
    * Invalidate comments & allow refetches again

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -273,9 +273,9 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
   });
 
   const accountStatus = profile
-    ? profile.isBanned === 1
+    ? profile.isBanned
       ? "BANNED"
-      : profile.isSilenced === 1
+      : profile.isSilenced
       ? "SILENCED"
       : "GOOD STANDING"
     : "Loading...";

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -272,6 +272,13 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
     });
   });
 
+  const accountStatus =
+    profile.isBanned === 1
+      ? "BANNED"
+      : profile.isSilenced === 1
+      ? "SILENCED"
+      : "GOOD STANDING";
+
   // Derived
   const canChange = userData && canClearUserNindo(userData);
   const availableRoles = userData && canChangeUserRole(userData.role);
@@ -455,6 +462,7 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
             </p>
             <p>Village: {profile.village?.name}</p>
             <p>Status: {profile.status}</p>
+            <p>Account Status: {accountStatus}</p>
             <p>Gender: {profile.gender}</p>
             <br />
             <b>Associations</b>

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -272,12 +272,13 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
     });
   });
 
-  const accountStatus =
-    profile.isBanned === 1
+  const accountStatus = profile
+    ? profile.isBanned === 1
       ? "BANNED"
       : profile.isSilenced === 1
       ? "SILENCED"
-      : "GOOD STANDING";
+      : "GOOD STANDING"
+    : "Loading...";
 
   // Derived
   const canChange = userData && canClearUserNindo(userData);

--- a/app/src/server/api/routers/profile.ts
+++ b/app/src/server/api/routers/profile.ts
@@ -903,6 +903,7 @@ export const profileRouter = createTRPCRouter({
             gender: true,
             isAi: true,
             isBanned: true,
+            isSilenced: true,
             isOutlaw: true,
             lastIp: true,
             level: true,


### PR DESCRIPTION
# Pull Request

Adds logic to check if the user is silenced when before the message is sent.

Fix #412 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced user account status visibility, displaying whether a user is "BANNED", "SILENCED", or in "GOOD STANDING".
	- Enhanced API to return the silenced status of users in public queries.
- **Bug Fixes**
	- Improved comment submission by notifying users who are silenced, preventing their messages from being sent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->