### PR TITLE
Fix Issue #414: Update Jutsu Transfer to add improvements

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -452,7 +452,7 @@ export const BLOODLINE_ROLL_TYPES = ["NATURAL", "ITEM"] as const;
 // Jutsu level transfer config
 export const JUTSU_TRANSFER_DAYS = 20;
 export const JUTSU_TRANSFER_COST = 20;
-export const JUTSU_TRANSFER_MAX_LEVEL = 20;
+export const JUTSU_TRANSFER_MAX_LEVEL = 25;
 export const JUTSU_TRANSFER_FREE_AMOUNT = 2;
 export const JUTSU_TRANSFER_FREE_NORMAL = 3;
 export const JUTSU_TRANSFER_FREE_SILVER = 4;


### PR DESCRIPTION
# Pull Request

Change max transfer level to 25 and allow users to select how many levels to transfer.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.
