### PR TITLE
Fix Issue #418: Users are being unsilenced before their silence time end

### DIFF
--- a/app/src/app/api/daily-reports/route.ts
+++ b/app/src/app/api/daily-reports/route.ts
@@ -37,13 +37,13 @@ export async function GET() {
 
     // Process each expired report
     for (const report of expiredReports) {
-      if (report.status === "BAN_ACTIVATED" && report.reportedUser?.isBanned && report.banEnd <= now) {
+      if (report.status === "BAN_ACTIVATED" && report.reportedUser?.isBanned && (report.banEnd ?? now)  <= now) {
         // Unban user if ban has expired
         await drizzleDB
           .update(userData)
           .set({ isBanned: false })
           .where(eq(userData.userId, report.reportedUser.userId));
-      } else if (report.status === "SILENCE_ACTIVATED" && report.reportedUser?.isSilenced && report.banEnd <= now) {
+      } else if (report.status === "SILENCE_ACTIVATED" && report.reportedUser?.isSilenced && (report.banEnd && now) <= now) {
         // Unsilence user if silence has expired
         await drizzleDB
           .update(userData)

--- a/app/src/app/api/daily-reports/route.ts
+++ b/app/src/app/api/daily-reports/route.ts
@@ -43,7 +43,7 @@ export async function GET() {
           .update(userData)
           .set({ isBanned: false })
           .where(eq(userData.userId, report.reportedUser.userId));
-      } else if (report.status === "SILENCE_ACTIVATED" && report.reportedUser?.isSilenced && (report.banEnd && now) <= now) {
+      } else if (report.status === "SILENCE_ACTIVATED" && report.reportedUser?.isSilenced && (report.banEnd ?? now) <= now) {
         // Unsilence user if silence has expired
         await drizzleDB
           .update(userData)

--- a/app/src/app/api/daily-reports/route.ts
+++ b/app/src/app/api/daily-reports/route.ts
@@ -14,6 +14,7 @@ export async function GET() {
 
   // Check timer
   const timerCheck = await lockWithDailyTimer(drizzleDB, ENDPOINT_NAME);
+  const now = new Date();
   // if (!timerCheck.isNewDay && timerCheck.response) return timerCheck.response;
 
   try {
@@ -36,16 +37,13 @@ export async function GET() {
 
     // Process each expired report
     for (const report of expiredReports) {
-      if (report.status === "BAN_ACTIVATED" && report.reportedUser?.isBanned) {
+      if (report.status === "BAN_ACTIVATED" && report.reportedUser?.isBanned && user.banEnd <= now) {
         // Unban user if ban has expired
         await drizzleDB
           .update(userData)
           .set({ isBanned: false })
           .where(eq(userData.userId, report.reportedUser.userId));
-      } else if (
-        report.status === "SILENCE_ACTIVATED" &&
-        report.reportedUser?.isSilenced
-      ) {
+      } else if (report.status === "SILENCE_ACTIVATED" && report.reportedUser?.isSilenced && user.banEnd <= now) {
         // Unsilence user if silence has expired
         await drizzleDB
           .update(userData)

--- a/app/src/app/api/daily-reports/route.ts
+++ b/app/src/app/api/daily-reports/route.ts
@@ -37,13 +37,13 @@ export async function GET() {
 
     // Process each expired report
     for (const report of expiredReports) {
-      if (report.status === "BAN_ACTIVATED" && report.reportedUser?.isBanned && user.banEnd <= now) {
+      if (report.status === "BAN_ACTIVATED" && report.reportedUser?.isBanned && report.banEnd <= now) {
         // Unban user if ban has expired
         await drizzleDB
           .update(userData)
           .set({ isBanned: false })
           .where(eq(userData.userId, report.reportedUser.userId));
-      } else if (report.status === "SILENCE_ACTIVATED" && report.reportedUser?.isSilenced && user.banEnd <= now) {
+      } else if (report.status === "SILENCE_ACTIVATED" && report.reportedUser?.isSilenced && report.banEnd <= now) {
         // Unsilence user if silence has expired
         await drizzleDB
           .update(userData)


### PR DESCRIPTION
# Pull Request

Adjusting logic on the daily reports to check if banEnd <= now before it changes isBanned and isSilenced to false.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the process for lifting account restrictions, ensuring that bans and silences are accurately removed based on the current time, leading to improved moderation outcomes for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->