### PR TITLE
Fix Issue#422: Combat QoL update

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -502,7 +502,7 @@ export const JUTSU_TRAIN_LEVEL_CAP = 25;
 export const MAX_DAILY_TRAININGS = 64;
 
 // Combat config
-export const BATTLE_ARENA_DAILY_LIMIT = 40;
+export const BATTLE_ARENA_DAILY_LIMIT = 99999;
 export const BATTLE_TAG_STACKING = true;
 export const RANKS_RESTRICTED_FROM_PVP = ["STUDENT", "GENIN"];
 

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -505,6 +505,7 @@ export const MAX_DAILY_TRAININGS = 64;
 export const BATTLE_ARENA_DAILY_LIMIT = 99999;
 export const BATTLE_TAG_STACKING = true;
 export const RANKS_RESTRICTED_FROM_PVP = ["STUDENT", "GENIN"];
+export const STREAK_LEVEL_DIFF = 10;
 
 // Black market config
 export const RYO_FOR_REP_DAYS_FROZEN = 3;

--- a/app/src/app/battlearena/page.tsx
+++ b/app/src/app/battlearena/page.tsx
@@ -67,7 +67,7 @@ export default function Arena() {
   let subtitle = "";
   switch (tab) {
     case "Arena":
-      subtitle = `Daily Training [${userData?.dailyArenaFights} / ${BATTLE_ARENA_DAILY_LIMIT}]`;
+      subtitle = `Battle Arena Fights Today: ${userData?.dailyArenaFights}`;
       break;
     case "Sparring":
       subtitle = "PVP Challenges";

--- a/app/src/layout/Post.tsx
+++ b/app/src/layout/Post.tsx
@@ -60,7 +60,7 @@ const Post: React.FC<PostProps> = (props) => {
   switch (props.user?.federalStatus) {
     case "NORMAL":
       userColor =
-        "bg-linear-to-r from-blue-800 via-blue-500 to-blue-800 bg-clip-text text-transparent font-black";
+        "bg-linear-to-r from-sky-500 via-sky-300 to-sky-500 bg-clip-text text-transparent font-black";
       break;
     case "SILVER":
       userColor =
@@ -133,18 +133,24 @@ const Post: React.FC<PostProps> = (props) => {
           </span>
         )}
         {props.user.villageKageId && props.user.villageKageId === props.user.userId && (
-          <span className="bg-slate-300 p-1 m-1 rounded-md">Kage</span>
+          <span className="bg-slate-300 p-1 m-1 rounded-md text-black">Kage</span>
         )}
         {props.user?.role !== "USER" && (
-          <span className={`${userRole} p-1 m-1 rounded-md`}>
+          <span
+            className={`${userRole} p-1 m-1 rounded-md ${
+              ["CODER", "MODERATOR", "JR_MODERATOR"].includes(props.user.role) 
+                ? "text-black" 
+                : ""
+            }`}
+          >
             {capitalizeFirstLetter(props.user?.role)}
           </span>
         )}
         {props.user.villageName && props.user.villageHexColor && (
-          <span
+          <span 
             className={`p-1 m-1 rounded-md ${
-              props.user.villageName.toLowerCase() === "glacier"
-                ? "text-black"
+              ["glacier", "shine", "shroud"].includes(props.user.villageName.toLowerCase()) 
+                ? "text-black" 
                 : "text-white"
             }`}
             style={{ backgroundColor: props.user.villageHexColor }}

--- a/app/src/libs/combat/database.ts
+++ b/app/src/libs/combat/database.ts
@@ -381,7 +381,7 @@ export const updateUser = async (
     // Any jutsus to be updated
     const jUsage = user.usedActions.filter((a) => a.type === "jutsu").map((a) => a.id);
     const jUnique = [...new Set(jUsage)];
-    const jExp = battleJutsuExp(curBattle.battleType, result.eloDiff);
+    const jExp = battleJutsuExp(curBattle.battleType, result.eloDiff, user);
     // If new prestige goes below 0, set allyVillage to false
     if (user.villagePrestige + result.villagePrestige < 0) {
       user.allyVillage = false;

--- a/app/src/libs/train.ts
+++ b/app/src/libs/train.ts
@@ -333,7 +333,7 @@ export const energyPerSecond = (speed: TrainingSpeed) => {
 export const battleJutsuExp = (battleType: BattleType, experienceGain: number, userData: UserData) => {
   switch (battleType) {
     case "COMBAT":
-      experienceGain * (1 + (userData.pvpStreak * 0.05));
+      return experienceGain * (1 + (userData.pvpStreak * 0.05));
     case "ARENA":
       return experienceGain * 0.5;
     case "QUEST":

--- a/app/src/libs/train.ts
+++ b/app/src/libs/train.ts
@@ -330,10 +330,10 @@ export const energyPerSecond = (speed: TrainingSpeed) => {
 };
 
 // Jutsu experience gain based on battle type
-export const battleJutsuExp = (battleType: BattleType, experienceGain: number) => {
+export const battleJutsuExp = (battleType: BattleType, experienceGain: number, userData: UserData) => {
   switch (battleType) {
     case "COMBAT":
-      return experienceGain;
+      experienceGain * (1 + (UserData.pvpStreak * 0.05));
     case "ARENA":
       return experienceGain * 0.5;
     case "QUEST":

--- a/app/src/libs/train.ts
+++ b/app/src/libs/train.ts
@@ -333,7 +333,7 @@ export const energyPerSecond = (speed: TrainingSpeed) => {
 export const battleJutsuExp = (battleType: BattleType, experienceGain: number, userData: UserData) => {
   switch (battleType) {
     case "COMBAT":
-      experienceGain * (1 + (UserData.pvpStreak * 0.05));
+      experienceGain * (1 + (userData.pvpStreak * 0.05));
     case "ARENA":
       return experienceGain * 0.5;
     case "QUEST":


### PR DESCRIPTION
# Pull Request

Re add the changes needed to uncap battle arena and adjust pvp exp.  Also contains some QoL for tavern title text colors and changes the color of normal fed.  Jutsu transfers now properly update to show the number of free attemps remaining and reflect when it will start charging rep.

fix #422 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Increased the daily engagement limit in the battle arena, allowing for significantly more battles per day than before.
  - Introduced a new constant for streak level differentiation.
  - Added functionality to provide experience boosts based on user streaks.
  
- **User Interface Enhancements**
  - Simplified the "Arena" tab subtitle for clearer user experience.
  - Updated visual representation of user roles and statuses, including color changes and improved text clarity.

- **Bug Fixes**
  - Enhanced the logic for displaying transfer costs based on user status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->