### PR TITLE
Fix Issue #432: Drain/poison now puts you into the negatives for pools

### DIFF
--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -584,8 +584,7 @@ export const applyEffects = (
           });
         }
         if (c.poison && c.poison > 0) {
-          target.curHealth -= c.poison;
-          target.curHealth = Math.min(target.maxHealth, target.curHealth);
+          target.curHealth = Math.max(0, Math.min(target.maxHealth, target.curHealth - c.poison));
           actionEffects.push({
             txt: `${target.username} takes ${c.poison.toFixed(2)} poison damage`,
             color: "purple",

--- a/app/src/libs/combat/process.ts
+++ b/app/src/libs/combat/process.ts
@@ -575,10 +575,9 @@ export const applyEffects = (
           });
         }
         if (c.drain && c.drain > 0 && target.curStamina > 0 && target.curChakra > 0) {
-          target.curChakra -= c.drain;
-          target.curChakra = Math.min(target.maxChakra, target.curChakra);
-          target.curStamina -= c.drain;
-          target.curStamina = Math.min(target.maxStamina, target.curStamina);
+          target.curChakra = Math.max(0, Math.min(target.maxChakra, target.curChakra - c.drain));
+          target.curStamina = Math.max(0, Math.min(target.maxStamina, target.curStamina - c.drain));
+        
           actionEffects.push({
             txt: `${user.username} is drained of ${c.drain.toFixed(2)} chakra and stamina`,
             color: "purple",


### PR DESCRIPTION
# Pull Request

Adjusts logic so that pools cannot go below 0. Fix #432 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined how character energy is adjusted during drain effects, ensuring stamina, chakra, and health values remain within valid limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->