### PR TITLE
Fix Issue #440: Change Battle Arena Exp

### DIFF
--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -527,17 +527,15 @@ export const calcBattleResult = (battle: CompleteBattle, userId: string) => {
       const streakBonus = 1 + user.pvpStreak * 0.05; // 5% per streak
       if (["COMBAT", "TOURNAMENT"].includes(battleType)) {
         experience *= 1.5;
-      } else if (battleType === "VILLAGE_PROTECTOR") {
+        if (battleType === "COMBAT") {
+          experience *= streakBonus;
+          experience = Math.min(experience, 100);
+        }
+      } else if (["CLAN_CHALLENGE", "KAGE_AI", "KAGE_PVP", "TRAINING", "VILLAGE_PROTECTOR"].includes(battleType)) {
         experience = 0;
-      } else if (
-        ["CLAN_CHALLENGE", "KAGE_AI", "KAGE_PVP", "TRAINING"].includes(battleType)
-      ) {
-        experience = 0;
+      } else if (battleType === "ARENA") {
+        experience = Math.min(experience, 20);
       }
-      // Calculate Final Experience
-      experience *= streakBonus;
-      // Cap experience at 100
-      experience = Math.min(experience, 100);
 
       // Find users who did not leave battle yet
       const friendsUsers = friends.filter((u) => !u.isAi);


### PR DESCRIPTION
# Pull Request

With the changes to the Battle Arena, a ton of exp was being grinded out.  To slow the exp gain a bit, the exp gain for BA is capped off at 20 per battle.  Users can still do unlimited battles.  In the process, I noticed that the pvp streak exp was affecting all battle types, including arena.  I moved the logic for the pvp streak bonus into a nested if statement within the exp calculation for pvp exp.

Fix #440 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined experience calculations to ensure consistent and fair rewards across different battle modes.
  - Adjusted bonus multipliers and caps for a more efficient and transparent experience system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->