### PR TITLE
Add a delete option for Achievements

### DIFF
--- a/app/src/layout/Logbook.tsx
+++ b/app/src/layout/Logbook.tsx
@@ -77,6 +77,7 @@ const LogbookAchievements: React.FC = () => {
     <div className="">
       {userData?.userQuests
         .filter((uq) => ["tier", "achievement"].includes(uq.quest.questType))
+        .filter((uq) => uq.completed === 0)
         ?.map((uq, i) => {
           const tracker = userData?.questData?.find((q) => q.id === uq.questId);
           return (

--- a/app/src/server/api/routers/quests.ts
+++ b/app/src/server/api/routers/quests.ts
@@ -350,7 +350,10 @@ export const questsRouter = createTRPCRouter({
         if (questData.questRank !== "A") {
           return errorResponse(`Only A rank missions/crimes are allowed`);
         }
-        if (!user.isOutlaw && !canAccessStructure(user, "/missionhall", sectorVillage)) {
+        if (
+          !user.isOutlaw &&
+          !canAccessStructure(user, "/missionhall", sectorVillage)
+        ) {
           return errorResponse("Must be in your allied village to start quest");
         }
         const current = user?.userQuests?.find(


### PR DESCRIPTION
Add a delete option for Achievements that are in a players logbook 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The quest log now shows only active challenges by filtering out completed quests, offering a more focused view of pending tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->