### PR TITLE
Fix Issue #484: Update EJ Outlaw rank to show as warlord

### DIFF
--- a/app/src/app/townhall/page.tsx
+++ b/app/src/app/townhall/page.tsx
@@ -200,12 +200,12 @@ const ElderHall: React.FC<{
           />
           {targetUser && (
             <div>
-              {targetUser.rank !== "JONIN" && (
+              {(targetUser.rank !== "JONIN" && targetUser.rank !== "ELITE JONIN") && (
                 <p className="text-red-500 font-bold text-center pt-2">
-                  User must be Jonin!
+                  User must be at least Jonin!
                 </p>
               )}
-              {targetUser.rank === "JONIN" && (
+              {(targetUser.rank === "JONIN" || targetUser.rank === "ELITE JONIN") && (
                 <Button
                   id="challenge"
                   className="mt-2 w-full"

--- a/app/src/layout/PublicUser.tsx
+++ b/app/src/layout/PublicUser.tsx
@@ -788,7 +788,7 @@ const PublicUserComponent: React.FC<PublicUserComponentProps> = (props) => {
             <TabsContent value="nindo">
               <ContentBox
                 title="Nindo"
-                subtitle={`${profile.username}&apos;s Ninja Way`}
+                subtitle={`${profile.username}'s Ninja Way`}
                 initialBreak={true}
                 topRightContent={
                   <div className="flex flex-row gap-1">

--- a/app/src/libs/profile.ts
+++ b/app/src/libs/profile.ts
@@ -160,7 +160,7 @@ export const showUserRank = (user: { rank: UserRank; isOutlaw: boolean }) => {
       case "JONIN":
         return "Higher Outlaw";
       case "ELITE JONIN":
-        return "Elite Outlaw";
+        return "Warlord";
       case "ELDER":
         return "Outlaw Council";
     }

--- a/app/src/libs/profile.ts
+++ b/app/src/libs/profile.ts
@@ -164,6 +164,9 @@ export const showUserRank = (user: { rank: UserRank; isOutlaw: boolean }) => {
       case "ELDER":
         return "Outlaw Council";
     }
+  } 
+  else if (user.rank === "ELITE JONIN"){
+    return "Elite Jonin";
   }
   return capitalizeFirstLetter(user.rank);
 };

--- a/app/src/libs/train.ts
+++ b/app/src/libs/train.ts
@@ -214,7 +214,7 @@ export const calcJutsuEquipLimit = (userdata: UserData) => {
       case "ELDER":
         return 7 + 2;
       case "ELITE JONIN":
-        return 8 + 2;
+        return 7 + 2;
     }
     return 4 + 2;
   };


### PR DESCRIPTION
# Pull Request

Updating the name of EJ to Warlord for outlaws

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the rank display: Users with a specific ELITE JONIN status will now see the designation "Warlord" instead of the previous label.
	- Adjusted eligibility messaging: Users must now meet the rank of at least Jonin to proceed, with updated feedback for rank requirements.
	- Modified jutsu equipment limit calculation for ELITE JONIN, reducing the total limit from 10 to 9.
- **Style**
	- Updated subtitle display in the Public User component for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->