### PR TITLE
:sparkles: Allow updating userIds across database

### DIFF
--- a/app/src/server/api/routers/staff.ts
+++ b/app/src/server/api/routers/staff.ts
@@ -2,7 +2,53 @@ import { createTRPCRouter, protectedProcedure } from "@/server/api/trpc";
 import { baseServerResponse, errorResponse } from "@/server/api/trpc";
 import { fetchBadge } from "@/routers/badge";
 import { eq, and } from "drizzle-orm";
-import { actionLog, userData, userItem, userJutsu, userBadge } from "@/drizzle/schema";
+import {
+  actionLog,
+  aiProfile,
+  automatedModeration,
+  bankTransfers,
+  bloodlineRolls,
+  captcha,
+  conceptImage,
+  conversation,
+  conversationComment,
+  damageSimulation,
+  forumPost,
+  forumThread,
+  historicalAvatar,
+  jutsuLoadout,
+  kageDefendedChallenges,
+  linkPromotion,
+  mpvpBattleUser,
+  notification,
+  paypalSubscription,
+  paypalTransaction,
+  poll,
+  pollOption,
+  questHistory,
+  reportLog,
+  ryoTrade,
+  supportReview,
+  trainingLog,
+  user2conversation,
+  userAttribute,
+  userBadge,
+  userBlackList,
+  userData,
+  userItem,
+  userJutsu,
+  userLikes,
+  userNindo,
+  userPollVote,
+  userReport,
+  userReportComment,
+  userRequest,
+  userReview,
+  userRewards,
+  userUpload,
+  userVote,
+  village,
+} from "@/drizzle/schema";
 import { fetchUser } from "@/routers/profile";
 import { getServerPusher, updateUserOnMap } from "@/libs/pusher";
 import { z } from "zod";
@@ -215,6 +261,272 @@ export const staffRouter = createTRPCRouter({
         );
       }
       return { success: true, message: "User copied" };
+    }),
+  // Update all occurances of a user ID in the database to another userId.
+  // VERY dangerous - used to e.g. link up unlinked accounts with new userIds from clerk
+  updateUserId: protectedProcedure
+    .input(z.object({ userId: z.string(), newUserId: z.string() }))
+    .output(baseServerResponse)
+    .mutation(async ({ ctx, input }) => {
+      // Query
+      const [user, fromUser, toUser] = await Promise.all([
+        fetchUser(ctx.drizzle, ctx.userId),
+        fetchUser(ctx.drizzle, input.userId),
+        ctx.drizzle.query.userData.findFirst({
+          where: eq(userData.userId, input.newUserId),
+        }),
+      ]);
+      // Guard
+      if (toUser) {
+        return { success: false, message: "UserId already exists" };
+      }
+      if (user.username !== "Terriator") {
+        return { success: false, message: "You are not Terriator" };
+      }
+      if (fromUser.role !== "USER") {
+        return { success: false, message: "Cannot change staff member's userId " };
+      }
+      // Mutate
+      await Promise.all([
+        ctx.drizzle
+          .update(userData)
+          .set({ userId: input.newUserId })
+          .where(eq(userData.userId, input.userId)),
+        ctx.drizzle
+          .update(aiProfile)
+          .set({ userId: input.newUserId })
+          .where(eq(aiProfile.userId, input.userId)),
+        ctx.drizzle
+          .update(userBlackList)
+          .set({ creatorUserId: input.newUserId })
+          .where(eq(userBlackList.creatorUserId, input.userId)),
+        ctx.drizzle
+          .update(userBlackList)
+          .set({ targetUserId: input.newUserId })
+          .where(eq(userBlackList.targetUserId, input.userId)),
+        ctx.drizzle
+          .update(bloodlineRolls)
+          .set({ userId: input.newUserId })
+          .where(eq(bloodlineRolls.userId, input.userId)),
+        ctx.drizzle
+          .update(captcha)
+          .set({ userId: input.newUserId })
+          .where(eq(captcha.userId, input.userId)),
+        ctx.drizzle
+          .update(mpvpBattleUser)
+          .set({ userId: input.newUserId })
+          .where(eq(mpvpBattleUser.userId, input.userId)),
+        ctx.drizzle
+          .update(conversation)
+          .set({ createdById: input.newUserId })
+          .where(eq(conversation.createdById, input.userId)),
+        ctx.drizzle
+          .update(user2conversation)
+          .set({ userId: input.newUserId })
+          .where(eq(user2conversation.userId, input.userId)),
+        ctx.drizzle
+          .update(conversationComment)
+          .set({ userId: input.newUserId })
+          .where(eq(conversationComment.userId, input.userId)),
+        ctx.drizzle
+          .update(damageSimulation)
+          .set({ userId: input.newUserId })
+          .where(eq(damageSimulation.userId, input.userId)),
+        ctx.drizzle
+          .update(forumPost)
+          .set({ userId: input.newUserId })
+          .where(eq(forumPost.userId, input.userId)),
+        ctx.drizzle
+          .update(forumThread)
+          .set({ userId: input.newUserId })
+          .where(eq(forumThread.userId, input.userId)),
+        ctx.drizzle
+          .update(historicalAvatar)
+          .set({ userId: input.newUserId })
+          .where(eq(historicalAvatar.userId, input.userId)),
+        ctx.drizzle
+          .update(jutsuLoadout)
+          .set({ userId: input.newUserId })
+          .where(eq(jutsuLoadout.userId, input.userId)),
+        ctx.drizzle
+          .update(notification)
+          .set({ userId: input.newUserId })
+          .where(eq(notification.userId, input.userId)),
+        ctx.drizzle
+          .update(paypalSubscription)
+          .set({ createdById: input.newUserId })
+          .where(eq(paypalSubscription.createdById, input.userId)),
+        ctx.drizzle
+          .update(paypalSubscription)
+          .set({ affectedUserId: input.newUserId })
+          .where(eq(paypalSubscription.affectedUserId, input.userId)),
+        ctx.drizzle
+          .update(paypalTransaction)
+          .set({ affectedUserId: input.newUserId })
+          .where(eq(paypalTransaction.affectedUserId, input.userId)),
+        ctx.drizzle
+          .update(paypalTransaction)
+          .set({ createdById: input.newUserId })
+          .where(eq(paypalTransaction.createdById, input.userId)),
+        ctx.drizzle
+          .update(ryoTrade)
+          .set({ creatorUserId: input.newUserId })
+          .where(eq(ryoTrade.creatorUserId, input.userId)),
+        ctx.drizzle
+          .update(ryoTrade)
+          .set({ purchaserUserId: input.newUserId })
+          .where(eq(ryoTrade.purchaserUserId, input.userId)),
+        ctx.drizzle
+          .update(ryoTrade)
+          .set({ allowedPurchaserId: input.newUserId })
+          .where(eq(ryoTrade.allowedPurchaserId, input.userId)),
+        ctx.drizzle
+          .update(reportLog)
+          .set({ targetUserId: input.newUserId })
+          .where(eq(reportLog.targetUserId, input.userId)),
+        ctx.drizzle
+          .update(reportLog)
+          .set({ staffUserId: input.newUserId })
+          .where(eq(reportLog.staffUserId, input.userId)),
+        ctx.drizzle
+          .update(actionLog)
+          .set({ userId: input.newUserId })
+          .where(eq(actionLog.userId, input.userId)),
+        ctx.drizzle
+          .update(trainingLog)
+          .set({ userId: input.newUserId })
+          .where(eq(trainingLog.userId, input.userId)),
+        ctx.drizzle
+          .update(userAttribute)
+          .set({ userId: input.newUserId })
+          .where(eq(userAttribute.userId, input.userId)),
+        ctx.drizzle
+          .update(userReview)
+          .set({ authorUserId: input.newUserId })
+          .where(eq(userReview.authorUserId, input.userId)),
+        ctx.drizzle
+          .update(userRewards)
+          .set({ awardedById: input.newUserId })
+          .where(eq(userRewards.awardedById, input.userId)),
+        ctx.drizzle
+          .update(userRewards)
+          .set({ receiverId: input.newUserId })
+          .where(eq(userRewards.receiverId, input.userId)),
+        ctx.drizzle
+          .update(userReview)
+          .set({ targetUserId: input.newUserId })
+          .where(eq(userReview.targetUserId, input.userId)),
+        ctx.drizzle
+          .update(userNindo)
+          .set({ userId: input.newUserId })
+          .where(eq(userNindo.userId, input.userId)),
+        ctx.drizzle
+          .update(userItem)
+          .set({ userId: input.newUserId })
+          .where(eq(userItem.userId, input.userId)),
+        ctx.drizzle
+          .update(userJutsu)
+          .set({ userId: input.newUserId })
+          .where(eq(userJutsu.userId, input.userId)),
+        ctx.drizzle
+          .update(userReport)
+          .set({ reporterUserId: input.newUserId })
+          .where(eq(userReport.reporterUserId, input.userId)),
+        ctx.drizzle
+          .update(userReport)
+          .set({ reportedUserId: input.newUserId })
+          .where(eq(userReport.reportedUserId, input.userId)),
+        ctx.drizzle
+          .update(userReportComment)
+          .set({ userId: input.newUserId })
+          .where(eq(userReportComment.userId, input.userId)),
+        ctx.drizzle
+          .update(bankTransfers)
+          .set({ senderId: input.newUserId })
+          .where(eq(bankTransfers.senderId, input.userId)),
+        ctx.drizzle
+          .update(bankTransfers)
+          .set({ receiverId: input.newUserId })
+          .where(eq(bankTransfers.receiverId, input.userId)),
+        ctx.drizzle
+          .update(automatedModeration)
+          .set({ userId: input.newUserId })
+          .where(eq(automatedModeration.userId, input.userId)),
+        ctx.drizzle
+          .update(supportReview)
+          .set({ userId: input.newUserId })
+          .where(eq(supportReview.userId, input.userId)),
+        ctx.drizzle
+          .update(kageDefendedChallenges)
+          .set({ userId: input.newUserId })
+          .where(eq(kageDefendedChallenges.userId, input.userId)),
+        ctx.drizzle
+          .update(kageDefendedChallenges)
+          .set({ kageId: input.newUserId })
+          .where(eq(kageDefendedChallenges.kageId, input.userId)),
+        ctx.drizzle
+          .update(questHistory)
+          .set({ userId: input.newUserId })
+          .where(eq(questHistory.userId, input.userId)),
+        ctx.drizzle
+          .update(userLikes)
+          .set({ userId: input.newUserId })
+          .where(eq(userLikes.userId, input.userId)),
+        ctx.drizzle
+          .update(conceptImage)
+          .set({ userId: input.newUserId })
+          .where(eq(conceptImage.userId, input.userId)),
+        ctx.drizzle
+          .update(userBadge)
+          .set({ userId: input.newUserId })
+          .where(eq(userBadge.userId, input.userId)),
+        ctx.drizzle
+          .update(userRequest)
+          .set({ senderId: input.newUserId })
+          .where(eq(userRequest.senderId, input.userId)),
+        ctx.drizzle
+          .update(userRequest)
+          .set({ receiverId: input.newUserId })
+          .where(eq(userRequest.receiverId, input.userId)),
+        ctx.drizzle
+          .update(linkPromotion)
+          .set({ userId: input.newUserId })
+          .where(eq(linkPromotion.userId, input.userId)),
+        ctx.drizzle
+          .update(linkPromotion)
+          .set({ reviewedBy: input.newUserId })
+          .where(eq(linkPromotion.reviewedBy, input.userId)),
+        ctx.drizzle
+          .update(userVote)
+          .set({ userId: input.newUserId })
+          .where(eq(userVote.userId, input.userId)),
+        ctx.drizzle
+          .update(poll)
+          .set({ createdByUserId: input.newUserId })
+          .where(eq(poll.createdByUserId, input.userId)),
+        ctx.drizzle
+          .update(pollOption)
+          .set({ targetUserId: input.newUserId })
+          .where(eq(pollOption.targetUserId, input.userId)),
+        ctx.drizzle
+          .update(pollOption)
+          .set({ createdByUserId: input.newUserId })
+          .where(eq(pollOption.createdByUserId, input.userId)),
+        ctx.drizzle
+          .update(village)
+          .set({ kageId: input.newUserId })
+          .where(eq(village.kageId, input.userId)),
+        ctx.drizzle
+          .update(userPollVote)
+          .set({ userId: input.newUserId })
+          .where(eq(userPollVote.userId, input.userId)),
+        ctx.drizzle
+          .update(userUpload)
+          .set({ userId: input.newUserId })
+          .where(eq(userUpload.userId, input.userId)),
+      ]);
+
+      return { success: true, message: "UserId updated" };
     }),
 });
 


### PR DESCRIPTION
# Pull Request
Allow me to update the userId of a user across the database, effectively assigning a user to a new clerk user

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a button for privileged users to update the user ID of a profile, accessible only to specific staff.
  - Introduced a confirmation dialog with form validation and warnings for this irreversible action.
  - Successful updates display a notification and refresh the user data.

- **Bug Fixes**
  - Ensured user ID changes are reflected across all related data for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->