### PR TITLE
Fix Issue #483: Display action name in log & allow event/content/coder to view full battle log

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -40,6 +40,9 @@ export const SHARED_COOLDOWN_TAGS = [
   "pierce",
   "debuffprevent",
   "buffprevent",
+  "cleanseprevent",
+  "clearprevent",
+  "seal",
 ] as const;
 
 export const LOG_TYPES = [

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -634,8 +634,8 @@ export const CLAN_REGEN_BOOST_COST = 300;
 export const CLAN_COLOR_CHANGE_REP_COST = 50;
 
 // Hideout and town costs
-export const HIDEOUT_COST = 1; // TODO: 50_000_000; // Ryo
-export const HIDEOUT_TOWN_UPGRADE = 1; // TODO: 2_000; // Reps
+export const HIDEOUT_COST = 50000000; // TODO: 50_000_000; // Ryo
+export const HIDEOUT_TOWN_UPGRADE = 2000; // TODO: 2_000; // Reps
 export const TOWN_REESTABLISH_COST = 30_000_000; // Ryo
 export const TOWN_MONTHLY_MAINTENANCE = 30_000; // Faction points
 export const FACTION_MIN_POINTS_FOR_TOWN = 1_000_000;

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -634,8 +634,8 @@ export const CLAN_REGEN_BOOST_COST = 300;
 export const CLAN_COLOR_CHANGE_REP_COST = 50;
 
 // Hideout and town costs
-export const HIDEOUT_COST = 50000000; // TODO: 50_000_000; // Ryo
-export const HIDEOUT_TOWN_UPGRADE = 2000; // TODO: 2_000; // Reps
+export const HIDEOUT_COST = 50_000_000;
+export const HIDEOUT_TOWN_UPGRADE = 2_000;
 export const TOWN_REESTABLISH_COST = 30_000_000; // Ryo
 export const TOWN_MONTHLY_MAINTENANCE = 30_000; // Faction points
 export const FACTION_MIN_POINTS_FOR_TOWN = 1_000_000;

--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -38,6 +38,8 @@ export const SHARED_COOLDOWN_TAGS = [
   "clear",
   "cleanse",
   "pierce",
+  "debuffprevent",
+  "buffprevent",
 ] as const;
 
 export const LOG_TYPES = [

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -548,6 +548,7 @@ export const insertAction = (info: {
       if (action.battleDescription === "") {
         action.battleDescription = `%user uses ${action.name}`;
       }
+      action.battleDescription = `${action.name}: ${action.battleDescription}`;
       action.battleDescription = action.battleDescription.replaceAll(
         "%user_subject",
         user.gender === "Male" ? "he" : "she",

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -130,6 +130,61 @@ export const availableUserActions = (
               data: userjutsu.jutsu,
             };
           })
+      : user?.jutsus && isStealth
+      ? user.jutsus
+          .filter((userjutsu) => {
+            // Filter out jutsus with damage tag when stealthed
+            const hasDamageTag = userjutsu.jutsu.effects.some(
+              (effect) => effect.type === "damage"
+            );
+            if (hasDamageTag) return false;
+            
+            // Still check for elemental seal
+            if (!elementalSeal?.elements?.length) return true;
+            const jutsuElements = new Set(
+              userjutsu.jutsu.effects.flatMap((effect) =>
+                "elements" in effect ? effect.elements : [],
+              ),
+            );
+            return (
+              jutsuElements.size === 0 ||
+              !elementalSeal.elements.some((e: ElementName) => jutsuElements.has(e))
+            );
+          })
+          .map((userjutsu) => {
+            return {
+              id: userjutsu.jutsu.id,
+              name: userjutsu.jutsu.name,
+              image: userjutsu.jutsu.image,
+              battleDescription: userjutsu.jutsu.battleDescription,
+              type: "jutsu" as const,
+              target: userjutsu.jutsu.target,
+              method: userjutsu.jutsu.method,
+              range: userjutsu.jutsu.range,
+              updatedAt: new Date(userjutsu.updatedAt).getTime(),
+              cooldown: userjutsu.jutsu.cooldown,
+              lastUsedRound: userjutsu.lastUsedRound,
+              healthCost: Math.max(
+                0,
+                userjutsu.jutsu.healthCost -
+                  userjutsu.jutsu.healthCostReducePerLvl * userjutsu.level,
+              ),
+              chakraCost: Math.max(
+                0,
+                userjutsu.jutsu.chakraCost -
+                  userjutsu.jutsu.chakraCostReducePerLvl * userjutsu.level,
+              ),
+              staminaCost: Math.max(
+                0,
+                userjutsu.jutsu.staminaCost -
+                  userjutsu.jutsu.staminaCostReducePerLvl * userjutsu.level,
+              ),
+              actionCostPerc: userjutsu.jutsu.actionCostPerc,
+              effects: userjutsu.jutsu.effects,
+              level: userjutsu.level,
+              data: userjutsu.jutsu,
+            };
+          })
       : []),
     ...(user?.items && !isStealth
       ? user.items
@@ -683,7 +738,11 @@ export const performBattleAction = (props: {
         actionPerformed = user.basicActions.find((ba) => ba.id === action.id);
         break;
     }
-    if (actionPerformed) actionPerformed.lastUsedRound = battle.round;
+    if (actionPerformed) {
+      actionPerformed.lastUsedRound = battle.round;
+      // Update the user's round to match the battle round
+      user.round = battle.round;
+    }
 
     // If this action has shared cooldown, update the rounds for all related actions
     if (actionHasSharedCooldown(action)) {

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -134,11 +134,11 @@ export const availableUserActions = (
       ? user.jutsus
           .filter((userjutsu) => {
             // Filter out jutsus with damage tag when stealthed
-            const hasDamageTag = userjutsu.jutsu.effects.some(
-              (effect) => effect.type === "damage"
+            const offensiveTags = new Set(["damage", "pierce", "drain"]);
+            const hasOffensiveTag = userjutsu.jutsu.effects.some((e) =>
+              offensiveTags.has(e.type),
             );
-            if (hasDamageTag) return false;
-            
+            if (hasOffensiveTag) return false;
             // Still check for elemental seal
             if (!elementalSeal?.elements?.length) return true;
             const jutsuElements = new Set(
@@ -738,8 +738,7 @@ export const performBattleAction = (props: {
         actionPerformed = user.basicActions.find((ba) => ba.id === action.id);
         break;
     }
-    if (actionPerformed)
-      actionPerformed.lastUsedRound = battle.round;
+    if (actionPerformed) actionPerformed.lastUsedRound = battle.round;
 
     // If this action has shared cooldown, update the rounds for all related actions
     if (actionHasSharedCooldown(action)) {

--- a/app/src/libs/combat/actions.ts
+++ b/app/src/libs/combat/actions.ts
@@ -738,11 +738,8 @@ export const performBattleAction = (props: {
         actionPerformed = user.basicActions.find((ba) => ba.id === action.id);
         break;
     }
-    if (actionPerformed) {
+    if (actionPerformed)
       actionPerformed.lastUsedRound = battle.round;
-      // Update the user's round to match the battle round
-      user.round = battle.round;
-    }
 
     // If this action has shared cooldown, update the rounds for all related actions
     if (actionHasSharedCooldown(action)) {

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -180,10 +180,6 @@ export const combatRouter = createTRPCRouter({
         columns: { role: true },
       });
       
-      if (!user) {
-        return errorResponse("User not found");
-      }
-
       const entries = await ctx.drizzle.query.battleAction.findMany({
         limit: canViewFullBattleLog(user.role) ? undefined : 30,
         where: eq(battleAction.battleId, input.battleId),

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -244,3 +244,13 @@ export const canClosePolls = (role: UserRole) => {
 export const canDeletePollOptions = (role: UserRole) => {
   return ["CONTENT-ADMIN", "CODING-ADMIN", "MODERATOR-ADMIN"].includes(role);
 };
+
+export const canViewFullBattleLog = (role: UserRole) => {
+  return [
+    "CODER",
+    "CONTENT",
+    "EVENT",
+    "CODING-ADMIN",
+    "CONTENT-ADMIN",
+  ].includes(role);
+};


### PR DESCRIPTION
# Pull Request

This change will allow coder and content/event staff to view the full battle log rather than the last 30 actions.  This will allow for better bug finding when issues are reported.  The battle log will also display what actions were taken.

Fix #483 

**Priority added to emergency update needed**

The rep and ryo cost for factions were set to 1 from both due to being shipped with the values being used in testing.

I have readjusted the constants to use 50 million ryo and 2000 reps.

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Battle descriptions now always begin with the action name for improved clarity.
  - Users with specific roles can view the full battle log without entry limits; others are limited to the most recent 30 entries.
  - New cooldown tags added to enhance battle effect management.
  - Stealth mode now filters out damaging jutsus, refining available user actions during combat.

- **Chores**
  - Added a new permission check to control access to the full battle log based on user role.
  - Updated hideout cost and town upgrade values to their final amounts for accurate gameplay balance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->