### PR TITLE
Fix Issue #483 & #488: Merge PR's

### DIFF
--- a/app/drizzle/constants.ts
+++ b/app/drizzle/constants.ts
@@ -38,6 +38,11 @@ export const SHARED_COOLDOWN_TAGS = [
   "clear",
   "cleanse",
   "pierce",
+  "debuffprevent",
+  "buffprevent",
+  "cleanseprevent",
+  "clearprevent",
+  "seal",
 ] as const;
 
 export const LOG_TYPES = [
@@ -634,8 +639,8 @@ export const CLAN_REGEN_BOOST_COST = 300;
 export const CLAN_COLOR_CHANGE_REP_COST = 50;
 
 // Hideout and town costs
-export const HIDEOUT_COST = 1; // TODO: 50_000_000; // Ryo
-export const HIDEOUT_TOWN_UPGRADE = 1; // TODO: 2_000; // Reps
+export const HIDEOUT_COST = 50_000_000;
+export const HIDEOUT_TOWN_UPGRADE = 2_000;
 export const TOWN_REESTABLISH_COST = 30_000_000; // Ryo
 export const TOWN_MONTHLY_MAINTENANCE = 30_000; // Faction points
 export const FACTION_MIN_POINTS_FOR_TOWN = 1_000_000;

--- a/app/src/layout/CombatActions.tsx
+++ b/app/src/layout/CombatActions.tsx
@@ -223,7 +223,7 @@ export const ActionOption: React.FC<ActionOptionProps> = (props) => {
               currentRound &&
               lastUsedRound &&
               cooldown - (currentRound - lastUsedRound) > 0 && (
-                <div className="absolute top-0 left-0 right-0 flex h-7 w-7 flex-row items-center justify-center rounded-full border-2 border-slate-400 bg-slate-300 text-black text-base font-bold z-10">
+                <div className="absolute bottom-0 left-0 right-0 flex h-7 w-7 flex-row items-center justify-center rounded-full border-2 border-slate-400 bg-slate-300 text-black text-base font-bold z-10">
                   {cooldown - (currentRound - lastUsedRound)}
                 </div>
               )}

--- a/app/src/layout/CombatHistory.tsx
+++ b/app/src/layout/CombatHistory.tsx
@@ -6,6 +6,7 @@ import { groupBy } from "@/utils/grouping";
 import { insertComponentsIntoText } from "@/utils/string";
 import { cn } from "src/libs/shadui";
 import { useRequiredUserData } from "@/utils/UserContext";
+import { canViewFullBattleLog } from "@/utils/permissions";
 import type { CombatResult } from "@/libs/combat/types";
 import type { ActionEffect } from "@/libs/combat/types";
 
@@ -28,9 +29,10 @@ const CombatHistory: React.FC<CombatHistoryProps> = (props) => {
       battleId: battleId,
       refreshKey: battleVersion ?? 0,
       checkBattle: results ? true : false,
+      limit: canViewFullBattleLog(userData?.role ?? "USER") ? 1000 : 30,
     },
     {
-      enabled: battleId !== undefined,
+      enabled: !!battleId && !!userData,
       placeholderData: (previousData) => previousData,
     },
   );

--- a/app/src/layout/EditContent.tsx
+++ b/app/src/layout/EditContent.tsx
@@ -685,9 +685,13 @@ export const EffectFormWrapper: React.FC<EffectFormWrapperProps> = (props) => {
   };
 
   // Parse how to present the tag form
-  const ignore = ["timeTracker", "type", "direction"];
+  const ignore = ["timeTracker", "type"];
   if (props.type === "bloodline") {
     ignore.push(...["rounds", "friendlyFire"]);
+  }
+  // Add direction to ignore list if not increasestat or decreasestat
+  if (!["increasestat", "decreasestat"].includes(tag.type)) {
+    ignore.push("direction");
   }
   const formData: FormEntry<Attribute>[] = attributes
     .filter((value) => !ignore.includes(value))

--- a/app/src/layout/ItemWithEffects.tsx
+++ b/app/src/layout/ItemWithEffects.tsx
@@ -437,6 +437,11 @@ const ItemWithEffects: React.FC<ItemWithEffectsProps> = (props) => {
                 <b>Method</b>: {item.method.toLowerCase()}
               </p>
             )}
+            {"direction" in item && typeof item.direction === "string" && item.direction && (
+              <p>
+                <b>Direction</b>: {item.direction.toLowerCase()}
+              </p>
+            )}
             {"weaponType" in item && item.weaponType && (
               <p>
                 <b>Weapon</b>: {item.weaponType.toLowerCase()}

--- a/app/src/layout/MenuBoxProfile.tsx
+++ b/app/src/layout/MenuBoxProfile.tsx
@@ -154,8 +154,10 @@ const MenuBoxProfile: React.FC = () => {
     }
   };
 
-  const expRequired = userData && calcLevelRequirements(userData.level);
-  const expCurrent = userData && Math.min(userData.experience, expRequired ?? 0);
+  const expRequired = userData && calcLevelRequirements(userData.level - 1);
+  const expForNextLevel = userData && calcLevelRequirements(userData.level);
+  const expTowardsNextLevel = userData && Math.max(0, userData.experience - (expRequired ?? 0));
+  const expNeededForNextLevel = userData && Math.max(1, (expForNextLevel ?? 0) - (expRequired ?? 0));
 
   return (
     <>
@@ -210,7 +212,7 @@ const MenuBoxProfile: React.FC = () => {
               total={battleUser?.maxStamina || userData?.maxStamina}
               timeDiff={timeDiff}
             />
-            {expRequired && expCurrent && expCurrent >= expRequired ? (
+            {expRequired && expForNextLevel && expTowardsNextLevel && expNeededForNextLevel && expTowardsNextLevel >= expNeededForNextLevel ? (
               <LevelUpBtn />
             ) : (
               <StatusBar
@@ -221,8 +223,8 @@ const MenuBoxProfile: React.FC = () => {
                 lastRegenAt={userData?.regenAt}
                 regen={0}
                 status={userData?.status}
-                current={expCurrent}
-                total={expRequired}
+                current={expTowardsNextLevel}
+                total={expNeededForNextLevel}
                 timeDiff={timeDiff}
               />
             )}

--- a/app/src/libs/combat/tags.ts
+++ b/app/src/libs/combat/tags.ts
@@ -256,95 +256,135 @@ export const adjustStats = (effect: UserEffect, target: BattleUserState) => {
       effect.statTypes?.forEach((stat) => {
         if (stat === "Highest") {
           if (effect.calculation === "static") {
-            switch (target.highestOffence) {
-              case "ninjutsuOffence":
-                target.ninjutsuOffence += power;
-                break;
-              case "genjutsuOffence":
-                target.genjutsuOffence += power;
-                break;
-              case "taijutsuOffence":
-                target.taijutsuOffence += power;
-                break;
-              case "bukijutsuOffence":
-                target.bukijutsuOffence += power;
-                break;
+            if (effect.direction === "offence" || effect.direction === "both") {
+              switch (target.highestOffence) {
+                case "ninjutsuOffence":
+                  target.ninjutsuOffence += power;
+                  break;
+                case "genjutsuOffence":
+                  target.genjutsuOffence += power;
+                  break;
+                case "taijutsuOffence":
+                  target.taijutsuOffence += power;
+                  break;
+                case "bukijutsuOffence":
+                  target.bukijutsuOffence += power;
+                  break;
+              }
             }
-            switch (target.highestDefence) {
-              case "ninjutsuDefence":
-                target.ninjutsuDefence += power;
-                break;
-              case "genjutsuDefence":
-                target.genjutsuDefence += power;
-                break;
-              case "taijutsuDefence":
-                target.taijutsuDefence += power;
-                break;
-              case "bukijutsuDefence":
-                target.bukijutsuDefence += power;
-                break;
+            if (effect.direction === "defence" || effect.direction === "both") {
+              switch (target.highestDefence) {
+                case "ninjutsuDefence":
+                  target.ninjutsuDefence += power;
+                  break;
+                case "genjutsuDefence":
+                  target.genjutsuDefence += power;
+                  break;
+                case "taijutsuDefence":
+                  target.taijutsuDefence += power;
+                  break;
+                case "bukijutsuDefence":
+                  target.bukijutsuDefence += power;
+                  break;
+              }
             }
-          } else if (effect.calculation === "percentage") {
-            switch (target.highestOffence) {
-              case "ninjutsuOffence":
-                target.ninjutsuOffence *= (100 + power) / 100;
-                break;
-              case "genjutsuOffence":
-                target.genjutsuOffence *= (100 + power) / 100;
-                break;
-              case "taijutsuOffence":
-                target.taijutsuOffence *= (100 + power) / 100;
-                break;
-              case "bukijutsuOffence":
-                target.bukijutsuOffence *= (100 + power) / 100;
-                break;
+          } else {
+            if (effect.direction === "offence" || effect.direction === "both") {
+              switch (target.highestOffence) {
+                case "ninjutsuOffence":
+                  target.ninjutsuOffence *= (100 + power) / 100;
+                  break;
+                case "genjutsuOffence":
+                  target.genjutsuOffence *= (100 + power) / 100;
+                  break;
+                case "taijutsuOffence":
+                  target.taijutsuOffence *= (100 + power) / 100;
+                  break;
+                case "bukijutsuOffence":
+                  target.bukijutsuOffence *= (100 + power) / 100;
+                  break;
+              }
             }
-            switch (target.highestDefence) {
-              case "ninjutsuDefence":
-                target.ninjutsuDefence *= (100 + power) / 100;
-                break;
-              case "genjutsuDefence":
-                target.genjutsuDefence *= (100 + power) / 100;
-                break;
-              case "taijutsuDefence":
-                target.taijutsuDefence *= (100 + power) / 100;
-                break;
-              case "bukijutsuDefence":
-                target.bukijutsuDefence *= (100 + power) / 100;
-                break;
+            if (effect.direction === "defence" || effect.direction === "both") {
+              switch (target.highestDefence) {
+                case "ninjutsuDefence":
+                  target.ninjutsuDefence *= (100 + power) / 100;
+                  break;
+                case "genjutsuDefence":
+                  target.genjutsuDefence *= (100 + power) / 100;
+                  break;
+                case "taijutsuDefence":
+                  target.taijutsuDefence *= (100 + power) / 100;
+                  break;
+                case "bukijutsuDefence":
+                  target.bukijutsuDefence *= (100 + power) / 100;
+                  break;
+              }
             }
           }
         } else if (stat === "Ninjutsu") {
           if (effect.calculation === "static") {
-            target.ninjutsuOffence += power;
-            target.ninjutsuDefence += power;
-          } else if (effect.calculation === "percentage") {
-            target.ninjutsuOffence *= (100 + power) / 100;
-            target.ninjutsuDefence *= (100 + power) / 100;
+            if (effect.direction === "offence" || effect.direction === "both") {
+              target.ninjutsuOffence += power;
+            }
+            if (effect.direction === "defence" || effect.direction === "both") {
+              target.ninjutsuDefence += power;
+            }
+          } else {
+            if (effect.direction === "offence" || effect.direction === "both") {
+              target.ninjutsuOffence *= (100 + power) / 100;
+            }
+            if (effect.direction === "defence" || effect.direction === "both") {
+              target.ninjutsuDefence *= (100 + power) / 100;
+            }
           }
         } else if (stat === "Genjutsu") {
           if (effect.calculation === "static") {
-            target.genjutsuOffence += power;
-            target.genjutsuDefence += power;
-          } else if (effect.calculation === "percentage") {
-            target.genjutsuOffence *= (100 + power) / 100;
-            target.genjutsuDefence *= (100 + power) / 100;
+            if (effect.direction === "offence" || effect.direction === "both") {
+              target.genjutsuOffence += power;
+            }
+            if (effect.direction === "defence" || effect.direction === "both") {
+              target.genjutsuDefence += power;
+            }
+          } else {
+            if (effect.direction === "offence" || effect.direction === "both") {
+              target.genjutsuOffence *= (100 + power) / 100;
+            }
+            if (effect.direction === "defence" || effect.direction === "both") {
+              target.genjutsuDefence *= (100 + power) / 100;
+            }
           }
         } else if (stat === "Taijutsu") {
           if (effect.calculation === "static") {
-            target.taijutsuOffence += power;
-            target.taijutsuDefence += power;
-          } else if (effect.calculation === "percentage") {
-            target.taijutsuOffence *= (100 + power) / 100;
-            target.taijutsuDefence *= (100 + power) / 100;
+            if (effect.direction === "offence" || effect.direction === "both") {
+              target.taijutsuOffence += power;
+            }
+            if (effect.direction === "defence" || effect.direction === "both") {
+              target.taijutsuDefence += power;
+            }
+          } else {
+            if (effect.direction === "offence" || effect.direction === "both") {
+              target.taijutsuOffence *= (100 + power) / 100;
+            }
+            if (effect.direction === "defence" || effect.direction === "both") {
+              target.taijutsuDefence *= (100 + power) / 100;
+            }
           }
         } else if (stat === "Bukijutsu") {
           if (effect.calculation === "static") {
-            target.bukijutsuOffence += power;
-            target.bukijutsuDefence += power;
-          } else if (effect.calculation === "percentage") {
-            target.bukijutsuOffence *= (100 + power) / 100;
-            target.bukijutsuDefence *= (100 + power) / 100;
+            if (effect.direction === "offence" || effect.direction === "both") {
+              target.bukijutsuOffence += power;
+            }
+            if (effect.direction === "defence" || effect.direction === "both") {
+              target.bukijutsuDefence += power;
+            }
+          } else {
+            if (effect.direction === "offence" || effect.direction === "both") {
+              target.bukijutsuOffence *= (100 + power) / 100;
+            }
+            if (effect.direction === "defence" || effect.direction === "both") {
+              target.bukijutsuDefence *= (100 + power) / 100;
+            }
           }
         }
       });
@@ -411,6 +451,7 @@ export const decreaseStats = (
   if (preventTag && preventTag.createdRound < effect.createdRound) {
     if (!pass) return preventResponse(effect, target, "cannot be debuffed");
   }
+  // Make power negative to decrease stats
   effect.power = -Math.abs(effect.power);
   effect.powerPerLevel = -Math.abs(effect.powerPerLevel);
   return adjustStats(effect, target);
@@ -896,7 +937,7 @@ export const damageCalc = (
 
 /** Calculate damage modifier, e.g. from weakness tag */
 export const calcDmgModifier = (
-  dmgEffect: UserEffect & (DamageTagType | PierceTagType),
+  dmgEffect: UserEffect & { type: "damage" | "pierce" },
   target: BattleUserState,
   usersState: UserEffect[],
 ) => {
@@ -1035,7 +1076,9 @@ export const fleePrevent = (
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
-    return getInfo(target, effect, "cannot flee");
+    const info = getInfo(target, effect, "cannot flee");
+    effect.power = 100;
+    return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
     return {
@@ -1102,6 +1145,7 @@ export const healPrevent = (
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
     const info = getInfo(target, effect, "cannot be healed");
+    effect.power = 100;
     return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
@@ -1253,22 +1297,52 @@ export const drain = (
   // Calculate drain amount
   const { power, qualifier } = getPower(effect);
 
-  // Apply drain effect each round
-  if (!effect.isNew && !effect.castThisRound) {
-    const drainAmount =
-      effect.calculation === "percentage"
-        ? Math.floor((power / 100) * Math.max(target.curChakra, target.curStamina))
-        : power;
+  // Get pools to drain from
+  const pools =
+    "poolsAffected" in effect && effect.poolsAffected
+      ? effect.poolsAffected
+      : ["Health" as const];
 
-    // Reduce target's Chakra and Stamina directly
-    const consequence = consequences.get(effect.targetId) || {
+  // Apply drain effect each round
+  if (
+    !effect.isNew &&
+    !effect.castThisRound &&
+    (effect.rounds === undefined || effect.rounds > 0)
+  ) {
+    const consequence: Consequence = consequences.get(effect.targetId) || {
       userId: effect.targetId,
       targetId: effect.targetId,
+      drain_hp: 0,
+      drain_cp: 0,
+      drain_sp: 0,
     };
 
-    consequence.drain = consequence.drain
-      ? consequence.drain + drainAmount
-      : drainAmount;
+    // Calculate drain amount for each pool
+    pools.forEach((pool) => {
+      const poolValue =
+        pool === "Health"
+          ? target.curHealth
+          : pool === "Chakra"
+            ? target.curChakra
+            : target.curStamina;
+      const drainAmount =
+        effect.calculation === "percentage"
+          ? Math.floor((power / 100) * poolValue)
+          : power;
+
+      // Add to existing drain value for the specific pool
+      switch (pool) {
+        case "Health":
+          consequence.drain_hp = (consequence.drain_hp || 0) + drainAmount;
+          break;
+        case "Chakra":
+          consequence.drain_cp = (consequence.drain_cp || 0) + drainAmount;
+          break;
+        case "Stamina":
+          consequence.drain_sp = (consequence.drain_sp || 0) + drainAmount;
+          break;
+      }
+    });
 
     consequences.set(effect.targetId, consequence);
   }
@@ -1276,7 +1350,7 @@ export const drain = (
   return getInfo(
     target,
     effect,
-    `will be drained ${qualifier} of Chakra and Stamina for ${effect.rounds} rounds`,
+    `will be drained ${qualifier} of ${pools.join(", ")} for ${effect.rounds} rounds`,
   );
 };
 
@@ -1362,6 +1436,29 @@ export const shield = (effect: UserEffect, target: BattleUserState) => {
   return info;
 };
 
+/** Prevents the user from being reduced below 1 HP */
+export const finalStand = (effect: UserEffect, target: BattleUserState) => {
+  const { power } = getPower(effect);
+  const primaryCheck = Math.random() < power / 100;
+  let info: ActionEffect | undefined = undefined;
+  if (effect.isNew && effect.castThisRound) {
+    if (primaryCheck) {
+      info = getInfo(
+        target,
+        effect,
+        "takes a final stand and cannot be reduced below 1 HP",
+      );
+    } else {
+      effect.rounds = 0;
+      info = {
+        txt: `${target.username}'s final stand failed to activate`,
+        color: "blue",
+      };
+    }
+  }
+  return info;
+};
+
 /**
  * Move user on the battlefield
  * 1. Remove user from current ground effect
@@ -1417,7 +1514,9 @@ export const movePrevent = (
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
-    return getInfo(target, effect, "cannot move");
+    const info = getInfo(target, effect, "cannot move");
+    effect.power = 100;
+    return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
     return {
@@ -1460,7 +1559,9 @@ export const onehitkillPrevent = (
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
-    return getInfo(target, effect, "cannot be one-hit-killed");
+    const info = getInfo(target, effect, "cannot be one-hit-killed");
+    effect.power = 100;
+    return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
     return {
@@ -1533,7 +1634,9 @@ export const robPrevent = (
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
-    return getInfo(target, effect, "cannot be robbed");
+    const info = getInfo(target, effect, "cannot be robbed");
+    effect.power = 100;
+    return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
     return {
@@ -1551,7 +1654,9 @@ export const cleansePrevent = (
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
-    return getInfo(target, effect, "cannot be cleansed");
+    const info = getInfo(target, effect, "cannot be cleansed");
+    effect.power = 100;
+    return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
     return {
@@ -1570,6 +1675,7 @@ export const clearPrevent = (
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
     const info = getInfo(target, effect, "cannot be cleared");
+    effect.power = 100;
     return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
@@ -1622,7 +1728,9 @@ export const sealPrevent = (
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
-    return getInfo(target, effect, "bloodline cannot be sealed");
+    const info = getInfo(target, effect, "bloodline cannot be sealed");
+    effect.power = 100;
+    return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
     return {
@@ -1699,7 +1807,9 @@ export const stunPrevent = (
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
-    return getInfo(target, effect, "cannot be stunned");
+    const info = getInfo(target, effect, "cannot be stunned");
+    effect.power = 100;
+    return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
     return {
@@ -1787,7 +1897,9 @@ export const summonPrevent = (
   const { power } = getPower(effect);
   const mainCheck = Math.random() < power / 100;
   if (mainCheck) {
-    return getInfo(target, effect, "cannot summon companions");
+    const info = getInfo(target, effect, "cannot summon companions");
+    effect.power = 100;
+    return info;
   } else if (effect.isNew) {
     effect.rounds = 0;
     return {

--- a/app/src/libs/combat/types.ts
+++ b/app/src/libs/combat/types.ts
@@ -190,7 +190,9 @@ export type Consequence = {
   absorb_hp?: number;
   absorb_sp?: number;
   absorb_cp?: number;
-  drain?: number;
+  drain_hp?: number;
+  drain_cp?: number;
+  drain_sp?: number;
   poison?: number;
   types?: (GeneralType | StatType | ElementName | PoolType | ZodAllTags["type"])[];
 };
@@ -367,6 +369,7 @@ export const IncreaseStatTag = z.object({
   ...IncludeStats,
   ...PowerAttributes,
   type: z.literal("increasestat").default("increasestat"),
+  direction: z.enum(["offence", "defence", "both"]).default("both"),
   description: msg("Increase stats of target"),
   calculation: z.enum(["static", "percentage"]).default("percentage"),
 });
@@ -376,6 +379,7 @@ export const DecreaseStatTag = z.object({
   ...IncludeStats,
   ...PowerAttributes,
   type: z.literal("decreasestat").default("decreasestat"),
+  direction: z.enum(["offence", "defence", "both"]).default("both"),
   description: msg("Decrease stats of target"),
   calculation: z.enum(["static", "percentage"]).default("percentage"),
 });
@@ -567,6 +571,15 @@ export const ShieldTag = z.object({
   health: z.coerce.number().int().min(1).max(100000).default(100),
 });
 export type ShieldTagType = z.infer<typeof ShieldTag>;
+
+export const FinalStandTag = z.object({
+  ...BaseAttributes,
+  type: z.literal("finalstand").default("finalstand"),
+  description: msg("%user cannot be reduced below 1 HP"),
+  power: z.coerce.number().min(0).max(100).default(100),
+  powerPerLevel: z.coerce.number().min(0).max(1).default(0),
+});
+export type FinalStandTagType = z.infer<typeof FinalStandTag>;
 
 export const MoveTag = z.object({
   ...BaseAttributes,
@@ -773,6 +786,7 @@ export const AllTags = z.union([
   DecreaseStatTag.default({}),
   DrainTag.default({}),
   ElementalSealTag.default({}),
+  FinalStandTag.default({}),
   FleePreventTag.default({}),
   FleeTag.default({}),
   HealPreventTag.default({}),

--- a/app/src/libs/combat/util.ts
+++ b/app/src/libs/combat/util.ts
@@ -325,6 +325,7 @@ export const sortEffects = (
     // Mid-modifiers
     "barrier",
     "shield",
+    "finalstand",
     "clone",
     "damage",
     "flee",
@@ -339,12 +340,12 @@ export const sortEffects = (
     "decreasedamagetaken",
     "increasedamagegiven",
     "increasedamagetaken",
-    "lifesteal",
-    "drain",
-    "poison",
     // Piercing damage
     "pierce",
     // Post-modifiers after pierce
+    "lifesteal",
+    "drain",
+    "poison",
     "absorb",
     "recoil",
     "reflect",
@@ -465,8 +466,14 @@ export const collapseConsequences = (acc: Consequence[], val: Consequence) => {
     if (val.types) {
       current.types = current.types ? current.types.concat(val.types) : val.types;
     }
-    if (val.drain) {
-      current.drain = current.drain ? current.drain + val.drain : val.drain;
+    if (val.drain_hp) {
+      current.drain_hp = current.drain_hp ? current.drain_hp + val.drain_hp : val.drain_hp;
+    }
+    if (val.drain_cp) {
+      current.drain_cp = current.drain_cp ? current.drain_cp + val.drain_cp : val.drain_cp;
+    }
+    if (val.drain_sp) {
+      current.drain_sp = current.drain_sp ? current.drain_sp + val.drain_sp : val.drain_sp;
     }
     if (val.poison) {
       current.poison = current.poison ? current.poison + val.poison : val.poison;

--- a/app/src/server/api/routers/combat.ts
+++ b/app/src/server/api/routers/combat.ts
@@ -171,11 +171,13 @@ export const combatRouter = createTRPCRouter({
         battleId: z.string(),
         refreshKey: z.number().optional(),
         checkBattle: z.boolean().optional(),
+        limit: z.number().optional(),
       }),
     )
     .query(async ({ ctx, input }) => {
+      const limit = input.limit ?? 30;
       const entries = await ctx.drizzle.query.battleAction.findMany({
-        limit: 30,
+        limit: limit,
         where: eq(battleAction.battleId, input.battleId),
         orderBy: [desc(battleAction.createdAt)],
       });

--- a/app/src/utils/permissions.ts
+++ b/app/src/utils/permissions.ts
@@ -244,3 +244,7 @@ export const canClosePolls = (role: UserRole) => {
 export const canDeletePollOptions = (role: UserRole) => {
   return ["CONTENT-ADMIN", "CODING-ADMIN", "MODERATOR-ADMIN"].includes(role);
 };
+
+export const canViewFullBattleLog = (role: UserRole) => {
+  return ["CODER", "CONTENT", "EVENT", "CODING-ADMIN", "CONTENT-ADMIN"].includes(role);
+};


### PR DESCRIPTION
# Pull Request

Allow picking whether stat increases effect offense or defense.  Add final stand tag.  Fixed a bug where when a prevent succeeds, it didn't always prevent the effect since it kept using the original power and recalculating when the prevented tag was used.  Drain is now properly split between pools.

A lot of changes were made in the tags.ts file, but I confirmed the changes work.

fix #488 

## License

By making this pull request, I confirm that I have the right to waive copyright and related rights to my contribution, and agree that all copyright and related rights in my contributions are waived, and I acknowledge that the Studie-Tech ApS organization has the copyright to use and modify my contribution for perpetuity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
  - Introduced a new "Final Stand" effect that prevents a character from being reduced below 1 HP under certain conditions.
  - Added support for configuring stat modification effects to target only offence, defence, or both.

- **Enhancements**
  - Stat increase and decrease effects now allow specifying their direction (offence, defence, or both).
  - The order of effect application now includes the new "Final Stand" effect.
  - The "direction" attribute is now conditionally shown in form fields and item details when applicable.
  - Cooldown counters on action icons are repositioned for improved visibility.
  - Damage drain effects now independently affect health, stamina, and chakra pools with clearer messaging.
  - Lifesteal effects now account for pierce-type damage dynamically.
  - Battle log query limits are now based on user permissions, allowing some roles to view full logs.
  - Expanded user role management permissions to include additional roles for content administrators.
  - Shared cooldown tags expanded with new prevention-related tags.
  - Updated hideout and town upgrade costs to final values.
  - Experience progress calculation updated for more accurate level progression display.

- **Bug Fixes**
  - The "direction" attribute for stat-modifying tags is now correctly displayed in relevant forms when applicable.

- **Balance Changes**
  - The "Basic Attack" action now uses the highest stat(s) for damage calculation instead of fixed stats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->